### PR TITLE
Export selected visible rows as CSV

### DIFF
--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -85,6 +85,15 @@ ending the browser session also clear the selection.
 
 ![Two documents selected on the current page while the authority card shows one document's details.](https://docbank.ai/assets/generated/web-page-selection.png)
 
+## Export selected rows as CSV
+
+Check file rows and choose **Export page CSV**. The download preserves their
+displayed order and includes the metadata already loaded, such as document IDs,
+versions, paths, sizes, timestamps, and hashes. Unavailable fields stay blank.
+It does not download document contents, fetch additional metadata, or include
+results beyond the loaded page. Formula-leading text is escaped for spreadsheet
+imports, and international filenames are preserved.
+
 ## Assign and remove tags
 
 1. Select a file or folder.

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -1,10 +1,12 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+
+import { parseCSV } from "../test-support/csv.js";
 
 const execFileAsync = promisify(execFile);
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -31,6 +33,7 @@ const searchResultsScreenshotPath = screenshotPathFor("web-search-results.png");
 const retainedVersionScreenshotPath = screenshotPathFor(
   "web-retained-version-download.png",
 );
+const visiblePageCSVScreenshotPath = path.join(repositoryRoot, ".superpowers", "web-visible-page-csv.png");
 const packedStorageScreenshotPath = screenshotPathFor("web-storage-status.png");
 
 async function expectDockInViewport(page: Page, dock: Locator): Promise<void> {
@@ -127,6 +130,7 @@ test.describe("Docbank web screenshots", () => {
     workspace = await mkdtemp(path.join(tmpdir(), "docbank-screenshot-"));
     vault = path.join(workspace, "vault");
     await mkdir(path.dirname(screenshotPath), { recursive: true, mode: 0o700 });
+    await mkdir(path.dirname(visiblePageCSVScreenshotPath), { recursive: true, mode: 0o700 });
     await rm(screenshotPath, { force: true });
     await rm(restoreScreenshotPath, { force: true });
     await rm(tagAssignmentScreenshotPath, { force: true });
@@ -137,6 +141,7 @@ test.describe("Docbank web screenshots", () => {
     await rm(tuiStorageScreenshotPath, { force: true });
     await rm(vaultBrowserScreenshotPath, { force: true });
     await rm(pageSelectionScreenshotPath, { force: true });
+    await rm(visiblePageCSVScreenshotPath, { force: true });
     await rm(pageSelectionMobileScreenshotPath, { force: true });
     await rm(searchResultsScreenshotPath, { force: true });
     await rm(retainedVersionScreenshotPath, { force: true });
@@ -178,6 +183,11 @@ test.describe("Docbank web screenshots", () => {
           { mode: 0o600 },
         ),
       ),
+    );
+    await writeFile(
+      path.join(reports, "résumé-日本語.txt"),
+      "Internationalized metadata download proof.\n",
+      { mode: 0o600 },
     );
     const archiveReference = path.join(
       workspace,
@@ -347,6 +357,125 @@ test.describe("Docbank web screenshots", () => {
       }
     }
     if (workspace) await rm(workspace, { recursive: true, force: true });
+  });
+
+  test("visible page CSV download", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("docbank-theme", "dark");
+    });
+    await page.goto(webURL, { waitUntil: "domcontentloaded" });
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation-duration: 0.001s !important;
+          animation-delay: 0s !important;
+          transition-duration: 0s !important;
+          caret-color: transparent !important;
+        }
+      `,
+    });
+
+    const reportsCell = page.getByRole("cell", { name: "Reports", exact: true });
+    await expect(reportsCell).toBeVisible();
+    const reportsResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "GET" &&
+        /\/api\/v1\/nodes\/\d+\/children\?limit=1000&offset=0$/.test(
+          new URL(response.url()).pathname + new URL(response.url()).search,
+        ),
+    );
+    await reportsCell.dblclick();
+    const reportsPage = (await (await reportsResponse).json()) as {
+      directory: { path?: string };
+      items: Array<{
+        id: number;
+        name: string;
+        current_version_id?: string;
+        blob_hash?: string;
+        md5?: string;
+        revision: number;
+      }>;
+    };
+    const report = page.getByRole("cell", {
+      name: "quarterly-tax-report.txt",
+      exact: true,
+    });
+    await expect(report).toBeVisible();
+    const filingSelection = page.getByRole("checkbox", {
+      name: "Select filing-checklist.md",
+    });
+    await filingSelection.click();
+    await expect(filingSelection).toBeFocused();
+    const reportSelection = page.getByRole("checkbox", {
+      name: "Select quarterly-tax-report.txt",
+    });
+    await reportSelection.click({ modifiers: ["Shift"] });
+    await expect(reportSelection).toBeFocused();
+    const unicodeSelection = page.getByRole("checkbox", {
+      name: "Select résumé-日本語.txt",
+    });
+    await unicodeSelection.click();
+    await expect(unicodeSelection).toBeFocused();
+    const selectionDock = page.getByRole("region", {
+      name: "Selected documents",
+    });
+    await expect(selectionDock).toContainText("3 selected on this page");
+    await expectDockInViewport(page, selectionDock);
+    const downloadPromise = page.waitForEvent("download");
+    await selectionDock
+      .getByRole("button", { name: "Export page CSV" })
+      .click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(
+      /^docbank-visible-page-\d{4}-\d{2}-\d{2}\.csv$/,
+    );
+    const downloadedPath = await download.path();
+    if (!downloadedPath) throw new Error("visible-page CSV download has no file");
+    const downloadedBytes = await readFile(downloadedPath);
+    expect(Array.from(downloadedBytes.subarray(0, 3))).toEqual([
+      0xef, 0xbb, 0xbf,
+    ]);
+    const csv = parseCSV(downloadedBytes.toString("utf8"));
+    const csvHeader = csv[0] ?? [];
+    const expectedNames = [
+      "filing-checklist.md",
+      "quarterly-tax-report.txt",
+      "résumé-日本語.txt",
+    ];
+    const expectedRows = reportsPage.items
+      .filter((item) => expectedNames.includes(item.name))
+      .sort((left, right) => left.name.localeCompare(right.name));
+    expect(
+      expectedRows.every((item) => /^[0-9a-f]{32}$/.test(item.md5 ?? "")),
+    ).toBe(true);
+    expect(csvHeader).toHaveLength(12);
+    expect(csv).toHaveLength(expectedRows.length + 1);
+    expect(
+      csv.slice(1).map((row) => ({
+        node_id: Number(row[0]),
+        content_version_id: row[1],
+        revision: Number(row[2]),
+        path: row[3],
+        name: row[4],
+        sha256: row[9],
+        md5: row[10],
+      })),
+    ).toEqual(
+      expectedRows.map((item) => ({
+        node_id: item.id,
+        content_version_id: item.current_version_id,
+        revision: item.revision,
+        path: `${reportsPage.directory.path}/${item.name}`,
+        name: item.name,
+        sha256: item.blob_hash,
+        md5: item.md5,
+      })),
+    );
+    await page.screenshot({
+      path: visiblePageCSVScreenshotPath,
+      fullPage: false,
+      animations: "disabled",
+    });
   });
 
   test("trash confirmation", async ({ page }) => {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -76,6 +76,7 @@
     type Tag,
     type TagAssignmentReceipt,
   } from "./api.js";
+  import { downloadVisiblePageCSV, selectedVisibleCSVRows } from "./csv.js";
   import { basename, formatBytes, formatDate } from "./format.js";
   import { orderRows, reconcileSearchView, type SortField } from "./rows.js";
   import { sortTags } from "./tagPresentation.js";
@@ -243,6 +244,11 @@
       ? selectVisibleDocuments(sortedRows)
       : clearSelection();
     pendingSelectionRange = false;
+  }
+
+  function exportPageCSV(): void {
+    const selectedRows = selectedVisibleCSVRows(sortedRows, bulkSelection.selectedIDs);
+    if (selectedRows.length > 0) downloadVisiblePageCSV(selectedRows);
   }
 
   function handleFailure(cause: unknown): void {
@@ -1556,6 +1562,7 @@
         onselectvisible={() => selectAllVisibleDocuments()}
         ontags={() => openBatchTags(bulkTargets)}
         tagsDisabled={loading}
+        oncsv={exportPageCSV}
       />
     {/if}
     {#if historyOpen && selected && membership?.protected}

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1100,6 +1100,74 @@ it("selects displayed files without requests or changing the inspector, then rec
   expect(screen.getByText("1 selected on this page")).toBeTruthy();
 });
 
+it("downloads the selected visible subset in displayed order without another request", async () => {
+  prepareSelectionApp();
+  const { fetchMock } = installSelectionBackend();
+  const downloaded: Blob[] = [];
+  const clicked: Array<{ download: string; href: string }> = [];
+  const createObjectURL = vi
+    .spyOn(URL, "createObjectURL")
+    .mockImplementation((blob) => {
+      downloaded.push(blob as Blob);
+      return `blob:visible-page-${downloaded.length}`;
+    });
+  const revokeObjectURL = vi
+    .spyOn(URL, "revokeObjectURL")
+    .mockImplementation(() => {});
+  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+    function (this: HTMLAnchorElement) {
+      clicked.push({ download: this.download, href: this.href });
+    },
+  );
+  render(App);
+
+  await fireEvent.dblClick(
+    await screen.findByRole("cell", { name: "Reports" }),
+  );
+  await screen.findByRole("checkbox", { name: "Select alpha.txt" });
+  await fireEvent.click(
+    screen.getByRole("checkbox", { name: "Select alpha.txt" }),
+  );
+  await fireEvent.click(
+    screen.getByRole("checkbox", { name: "Select gamma.txt" }),
+  );
+  await fireEvent.click(screen.getByRole("button", { name: "Size" }));
+  const requestsBeforeExport = fetchMock.mock.calls.length;
+
+  const exportButton = screen.getByRole("button", { name: "Export page CSV" });
+  await fireEvent.click(exportButton);
+  await fireEvent.click(exportButton);
+
+  expect(fetchMock.mock.calls).toHaveLength(requestsBeforeExport);
+  expect(createObjectURL).toHaveBeenCalledTimes(2);
+  expect(revokeObjectURL.mock.calls).toEqual([
+    ["blob:visible-page-1"],
+    ["blob:visible-page-2"],
+  ]);
+  expect(clicked).toHaveLength(2);
+  expect(clicked[0]?.href).toBe("blob:visible-page-1");
+  expect(clicked[0]?.download).toMatch(
+    /^docbank-visible-page-\d{4}-\d{2}-\d{2}\.csv$/,
+  );
+  expect(downloaded[0]?.type).toBe("text/csv;charset=utf-8");
+
+  const bytes = new Uint8Array(await downloaded[0]!.arrayBuffer());
+  expect(Array.from(bytes.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf]);
+
+  const records = (await downloaded[0]!.text())
+    .split("\r\n")
+    .filter((record) => record !== "");
+  expect(records).toHaveLength(3);
+  expect(records[1]).toContain(
+    '12,"00000012-1111-4111-8111-111111111111",1,"/Reports/gamma.txt"',
+  );
+  expect(records[1]).toContain(`"${"c".repeat(64)}"`);
+  expect(records[2]).toContain(
+    '10,"00000010-1111-4111-8111-111111111111",1,"/Reports/alpha.txt"',
+  );
+  expect(records[2]).toContain(`"${"a".repeat(64)}"`);
+});
+
 it("clears page selection across folder, Back, query, tag-filter, and session transitions", async () => {
   prepareSelectionApp();
   installSelectionBackend();

--- a/frontend/src/SelectionDock.svelte
+++ b/frontend/src/SelectionDock.svelte
@@ -9,6 +9,7 @@
     onselectvisible: () => void;
     ontags?: () => void;
     tagsDisabled?: boolean;
+    oncsv: () => void;
   }
 
   let {
@@ -19,6 +20,7 @@
     onselectvisible,
     ontags,
     tagsDisabled = false,
+    oncsv,
   }: Props = $props();
 </script>
 
@@ -50,6 +52,7 @@
     {#if ontags}
       <Button size="sm" disabled={tagsDisabled} onclick={ontags}>Edit tags</Button>
     {/if}
+    <Button size="sm" onclick={oncsv}>Export page CSV</Button>
   </div>
 </BottomDock>
 

--- a/frontend/src/SelectionDock.test.ts
+++ b/frontend/src/SelectionDock.test.ts
@@ -28,6 +28,7 @@ it("describes a truncated page-local selection and exposes local controls", asyn
     truncated: true,
     onclear,
     onselectvisible,
+    oncsv: vi.fn(),
   });
 
   const dock = screen.getByRole("region", { name: "Selected documents" });
@@ -55,6 +56,7 @@ it("uses the dock close control to clear selection", async () => {
     truncated: false,
     onclear,
     onselectvisible: vi.fn(),
+    oncsv: vi.fn(),
   });
 
   expect(screen.queryByText("More results exist beyond this page")).toBeNull();
@@ -74,10 +76,28 @@ it("offers the bounded tag action when supplied", async () => {
     onselectvisible: vi.fn(),
     ontags,
     tagsDisabled: true,
+    oncsv: vi.fn(),
   });
 
   expect((screen.getByRole("button", { name: "Edit tags" }) as HTMLButtonElement).disabled).toBe(true);
   await rerender({ tagsDisabled: false });
   await fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
   expect(ontags).toHaveBeenCalledOnce();
+});
+
+it("labels and invokes the visible-page CSV action for the current selection", async () => {
+  const oncsv = vi.fn();
+  render(SelectionDock, {
+    selectedCount: 2,
+    visibleDocumentCount: 2,
+    truncated: false,
+    onclear: vi.fn(),
+    onselectvisible: vi.fn(),
+    oncsv,
+  });
+
+  await fireEvent.click(
+    screen.getByRole("button", { name: "Export page CSV" }),
+  );
+  expect(oncsv).toHaveBeenCalledOnce();
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -5,6 +5,7 @@ export interface Node {
   kind: "dir" | "file";
   current_version_id?: string;
   blob_hash?: string;
+  md5?: string;
   size: number;
   mime_type?: string;
   revision: number;

--- a/frontend/src/csv.test.ts
+++ b/frontend/src/csv.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { parseCSV } from "../test-support/csv.js";
+import type { Node } from "./api.js";
+import {
+  buildVisiblePageCSV,
+  selectedVisibleCSVRows,
+  type VisibleCSVRow,
+} from "./csv.js";
+
+const headers = [
+  "node_id",
+  "content_version_id",
+  "revision",
+  "path",
+  "name",
+  "mime_type",
+  "size_bytes",
+  "created_at",
+  "modified_at",
+  "sha256",
+  "md5",
+  "match",
+];
+
+function node(id: number, overrides: Partial<Node> = {}): Node {
+  return {
+    id,
+    name: `document-${id}.txt`,
+    kind: "file",
+    current_version_id: `version-${id}`,
+    blob_hash: `sha256-${id}`,
+    size: id * 10,
+    mime_type: "text/plain",
+    revision: id + 20,
+    created_at: "2026-09-01T10:11:12Z",
+    modified_at: "2026-09-02T13:14:15Z",
+    ...overrides,
+  };
+}
+
+describe("visible-page CSV", () => {
+  it("accepts one file-leading BOM without changing later cell content", () => {
+    expect(parseCSV('\uFEFF"heading"\r\n"kept\uFEFFvalue"\r\n')).toEqual([
+      ["heading"],
+      ["kept\uFEFFvalue"],
+    ]);
+  });
+
+  it("reports an unterminated quoted field", () => {
+    expect(() => parseCSV('"unterminated')).toThrowError(
+      "CSV has an unterminated quoted field",
+    );
+  });
+
+  it("reports data after a closing quote", () => {
+    expect(() => parseCSV('"closed"x\r\n')).toThrowError(
+      "CSV has an unexpected character after a closing quote",
+    );
+  });
+
+  it("exports stable columns with exact visible node authority and blank absent metadata", () => {
+    const rows: VisibleCSVRow[] = [
+      {
+        node: node(41, {
+          current_version_id: "76d80170-1cd3-4f35-9580-e6bfc1c4f9e1",
+          blob_hash: "a".repeat(64),
+          md5: "f6fdffe48c908deb0f4c3bd36c032e72",
+          revision: 117,
+          size: 987_654,
+        }),
+        path: "/Cases/alpha.txt",
+        match: "content",
+      },
+      {
+        node: node(42, {
+          current_version_id: undefined,
+          blob_hash: undefined,
+          mime_type: undefined,
+        }),
+        path: "/Cases/document-42.txt",
+      },
+    ];
+
+    const parsed = parseCSV(buildVisiblePageCSV(rows));
+
+    expect(parsed).toHaveLength(3);
+    expect(parsed.every((record) => record.length === headers.length)).toBe(true);
+    expect(parsed[0]).toEqual(headers);
+    expect(parsed[1]).toEqual([
+      "41",
+      "76d80170-1cd3-4f35-9580-e6bfc1c4f9e1",
+      "117",
+      "/Cases/alpha.txt",
+      "document-41.txt",
+      "text/plain",
+      "987654",
+      "2026-09-01T10:11:12Z",
+      "2026-09-02T13:14:15Z",
+      "a".repeat(64),
+      "f6fdffe48c908deb0f4c3bd36c032e72",
+      "content",
+    ]);
+    expect(parsed[2]).toEqual([
+      "42",
+      "",
+      "62",
+      "/Cases/document-42.txt",
+      "document-42.txt",
+      "",
+      "420",
+      "2026-09-01T10:11:12Z",
+      "2026-09-02T13:14:15Z",
+      "",
+      "",
+      "",
+    ]);
+  });
+
+  it("preserves RFC4180 comma, quote, newline, and Unicode values", () => {
+    const csv = buildVisiblePageCSV([
+      {
+        node: node(7, { name: 'Budget, "final"\n日本語.txt' }),
+        path: '/Reports, 2026/Budget, "final"\n日本語.txt',
+        match: "name",
+      },
+    ]);
+
+    expect(csv.endsWith("\r\n")).toBe(true);
+    expect(csv).toContain('"Budget, ""final""\n日本語.txt"');
+    const parsed = parseCSV(csv);
+    expect(parsed[1]?.[3]).toBe('/Reports, 2026/Budget, "final"\n日本語.txt');
+    expect(parsed[1]?.[4]).toBe('Budget, "final"\n日本語.txt');
+  });
+
+  it.each(["=SUM(A1:A2)", "+cmd", "-2+3", "@lookup", " \t=hidden", "\u0001@hidden"])(
+    "neutralizes formula-leading textual cell %j",
+    (hostile) => {
+      const parsed = parseCSV(
+        buildVisiblePageCSV([
+          {
+            node: node(9, { name: hostile }),
+            path: hostile,
+            match: "name",
+          },
+        ]),
+      );
+
+      expect(parsed[1]?.[3]).toBe(`'${hostile}`);
+      expect(parsed[1]?.[4]).toBe(`'${hostile}`);
+      expect(parsed[1]?.[6]).toBe("90");
+    },
+  );
+
+  it("keeps selected visible files in displayed order", () => {
+    const displayed = [
+      { node: node(3), path: "/zeta.txt", match: "name" as const },
+      { node: node(1), path: "/alpha.txt", match: "content" as const },
+      {
+        node: node(2, { kind: "dir" }),
+        path: "/folder",
+      },
+      { node: node(4), path: "/unselected.txt" },
+    ];
+
+    expect(
+      selectedVisibleCSVRows(displayed, new Set([1, 99, 3, 2])).map(
+        (row) => row.node.id,
+      ),
+    ).toEqual([3, 1]);
+  });
+
+  it("serializes 1000 synthetic visible rows", () => {
+    const rows = Array.from({ length: 1_000 }, (_, index) => ({
+      node: node(index + 1),
+      path: `/Synthetic/document-${index + 1}.txt`,
+      match: index % 2 === 0 ? ("name" as const) : ("content" as const),
+    }));
+
+    const started = performance.now();
+    const parsed = parseCSV(buildVisiblePageCSV(rows));
+    const elapsed = performance.now() - started;
+    console.info(`CSV1000 elapsed_ms=${elapsed.toFixed(3)}`);
+
+    expect(parsed).toHaveLength(1_001);
+    expect(parsed.every((record) => record.length === headers.length)).toBe(true);
+    expect(parsed[1]?.[0]).toBe("1");
+    expect(parsed[1_000]?.[0]).toBe("1000");
+    expect(parsed[1_000]?.[11]).toBe("content");
+  });
+});

--- a/frontend/src/csv.ts
+++ b/frontend/src/csv.ts
@@ -1,0 +1,90 @@
+import type { Node } from "./api.js";
+
+export type VisibleCSVRow = {
+  node: Node;
+  path: string;
+  match?: "name" | "content";
+};
+
+const columns = [
+  "node_id",
+  "content_version_id",
+  "revision",
+  "path",
+  "name",
+  "mime_type",
+  "size_bytes",
+  "created_at",
+  "modified_at",
+  "sha256",
+  "md5",
+  "match",
+] as const;
+
+const spreadsheetFormula = /^[\p{White_Space}\p{Cc}]*[=+\-@]/u;
+
+function textCell(value: string | undefined): string {
+  const safe = value && spreadsheetFormula.test(value) ? `'${value}` : (value ?? "");
+  return `"${safe.replaceAll('"', '""')}"`;
+}
+
+function record(cells: readonly (string | number | undefined)[]): string {
+  return cells
+    .map((cell) => (typeof cell === "number" ? String(cell) : textCell(cell)))
+    .join(",");
+}
+
+export function selectedVisibleCSVRows(
+  displayedRows: readonly VisibleCSVRow[],
+  selectedIDs: ReadonlySet<number>,
+): VisibleCSVRow[] {
+  return displayedRows.filter(
+    (row) => row.node.kind === "file" && selectedIDs.has(row.node.id),
+  );
+}
+
+export function buildVisiblePageCSV(rows: readonly VisibleCSVRow[]): string {
+  const records = [
+    record(columns),
+    ...rows.map(({ node, path, match }) =>
+      record([
+        node.id,
+        node.current_version_id,
+        node.revision,
+        path,
+        node.name,
+        node.mime_type,
+        node.size,
+        node.created_at,
+        node.modified_at,
+        node.blob_hash,
+        node.md5,
+        match,
+      ]),
+    ),
+  ];
+  return `${records.join("\r\n")}\r\n`;
+}
+
+export function visiblePageCSVFilename(now = new Date()): string {
+  return `docbank-visible-page-${now.toISOString().slice(0, 10)}.csv`;
+}
+
+export function downloadVisiblePageCSV(
+  rows: readonly VisibleCSVRow[],
+  now = new Date(),
+): void {
+  const url = URL.createObjectURL(
+    new Blob(["\uFEFF", buildVisiblePageCSV(rows)], {
+      type: "text/csv;charset=utf-8",
+    }),
+  );
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = visiblePageCSVFilename(now);
+    anchor.click();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/frontend/test-support/csv.ts
+++ b/frontend/test-support/csv.ts
@@ -1,0 +1,66 @@
+export function parseCSV(csv: string): string[][] {
+  const records: string[][] = [];
+  let record: string[] = [];
+  let field = "";
+  let quoted = false;
+  let closedQuote = false;
+
+  const finishField = (): void => {
+    record.push(field);
+    field = "";
+    closedQuote = false;
+  };
+  const finishRecord = (): void => {
+    finishField();
+    records.push(record);
+    record = [];
+  };
+
+  for (
+    let index = csv.startsWith("\uFEFF") ? 1 : 0;
+    index < csv.length;
+    index += 1
+  ) {
+    const character = csv[index];
+    if (quoted) {
+      if (character === '"' && csv[index + 1] === '"') {
+        field += '"';
+        index += 1;
+      } else if (character === '"') {
+        quoted = false;
+        closedQuote = true;
+      } else field += character;
+      continue;
+    }
+
+    if (closedQuote) {
+      if (character === ",") finishField();
+      else if (character === "\r" && csv[index + 1] === "\n") {
+        finishRecord();
+        index += 1;
+      } else {
+        throw new Error("CSV has an unexpected character after a closing quote");
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      if (field !== "") {
+        throw new Error("CSV has an unexpected quote in an unquoted field");
+      }
+      quoted = true;
+    } else if (character === ",") finishField();
+    else if (character === "\r" && csv[index + 1] === "\n") {
+      finishRecord();
+      index += 1;
+    } else if (character === "\r" || character === "\n") {
+      throw new Error("CSV has a bare record separator");
+    } else field += character;
+  }
+
+  if (quoted) throw new Error("CSV has an unterminated quoted field");
+  if (closedQuote || record.length > 0 || field !== "") {
+    throw new Error("CSV has an incomplete final record");
+  }
+  return records;
+}


### PR DESCRIPTION
## What changed

- Export checked file rows as CSV, in their displayed order.
- Include the metadata already loaded, including available SHA-256 and MD5 hashes. Missing fields stay blank.
- Preserve international filenames and escape formula-leading text for spreadsheet imports.

## Why

The selected rows can now become a small metadata report without downloading document contents or fetching more results.

## Usage

Check file rows and choose **Export page CSV**. Use **Select visible documents** first to export every file on the loaded page. Results beyond that page are not included.

![Three synthetic documents selected for CSV export in the actual web app.](https://raw.githubusercontent.com/salmonumbrella/docbank/33f37b0cd7772a612e735abd3b6651076dffffba/web-visible-page-csv.png)
