### PR TITLE
Add document keyboard shortcuts

### DIFF
--- a/cmd/docbank/cli_test.go
+++ b/cmd/docbank/cli_test.go
@@ -80,19 +80,9 @@ func setupVaultHome(t *testing.T) string {
 // production; no test-only transport exists.
 func startTestDaemon(t *testing.T, dir string) {
 	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- runServe(ctx) }()
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(10 * time.Second):
-			t.Error("test daemon did not shut down")
-		}
-	})
+	startServe(t)
 	require.Eventually(t, func() bool {
-		_, _, ok, err := client.Find(ctx, dir)
+		_, _, ok, err := client.Find(t.Context(), dir)
 		return err == nil && ok
 	}, 30*time.Second, 25*time.Millisecond, "test daemon never became ready")
 }

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-09-11
+last_edited: 2026-09-12
 title: Web application
 description: Upload, browse, search, and organize the local vault in a responsive, authenticated web interface.
 ---
@@ -21,7 +21,7 @@ The daemon accepts connections only from the local machine.
 
 Choose a task:
 
-- [Browse the vault](#browse-the-vault), inspect document details, or
+- [Browse the vault](#browse-the-vault), [use keyboard shortcuts](#use-keyboard-shortcuts), inspect document details, or
   [select documents on this page](#select-documents-on-this-page).
 - [Upload files](#upload-verified-documents) or [download content](#download-verified-content).
 - [Manage tags](#manage-tag-definitions) and [search text](#browse-tags-and-search-text).
@@ -65,6 +65,27 @@ even when the card wraps it across lines. Every selected node also shows its
 assigned tag names. Hovering a tag shows its stable UUID and vault-wide
 assignment count; the bounded tag stack expands in place when a node carries
 more than six.
+
+## Use keyboard shortcuts
+
+Press <kbd>?</kbd> or choose the keyboard button in the top bar to see every
+shortcut. Press <kbd>/</kbd> to focus search, <kbd>j</kbd> or <kbd>k</kbd> to
+inspect the next or previous loaded row, <kbd>Space</kbd> to check or uncheck
+the inspected file, <kbd>Enter</kbd> to open the inspected folder, and
+<kbd>Escape</kbd> to clear page selection. Row navigation stops at the loaded
+page boundary and never fetches another page.
+
+The same help dialog can assign digits <kbd>1</kbd> through <kbd>9</kbd> to tag
+definitions. Bindings are separate for each vault and stay in this browser for
+the current daemon run. Reopening the page keeps them; restarting the daemon or
+clearing browser data requires setting them again.
+
+Pressing a configured digit toggles that tag on the one inspected
+file, independent of checked documents. Docbank waits for the file's complete
+assigned-tag list and sends its displayed revision with the change. A stale
+revision remains visible as an error and is never retried against newer state.
+
+App shortcuts pause while a text field, control, or dialog owns the keyboard.
 
 ## Select documents on this page
 

--- a/document/pymupdf/provider_test.go
+++ b/document/pymupdf/provider_test.go
@@ -140,7 +140,7 @@ func TestProviderRejectsMalformedPartialAndDriftedOutput(t *testing.T) {
 }
 
 func TestProviderAcceptsExplicitlyExplainedEmptyPage(t *testing.T) {
-	provider := newTestProvider(t, helperExecutable(t, "empty-explained"), time.Second, 1<<20)
+	provider := newTestProvider(t, helperExecutable(t, "empty-explained"), 30*time.Second, 1<<20)
 	upload := newTestUpload(testPDF(2))
 
 	result, err := provider.Render(t.Context(), upload,
@@ -152,14 +152,14 @@ func TestProviderAcceptsExplicitlyExplainedEmptyPage(t *testing.T) {
 
 func TestProviderBoundsOutputAndSanitizesProcessFailure(t *testing.T) {
 	t.Run("oversized stdout", func(t *testing.T) {
-		provider := newTestProvider(t, helperExecutable(t, "oversized"), time.Second, 1024)
+		provider := newTestProvider(t, helperExecutable(t, "oversized"), 30*time.Second, 1024)
 		upload := newTestUpload(testPDF(2))
 		_, err := provider.Render(t.Context(), upload,
 			testAuthorization(provider.Descriptor(), upload.Metadata()))
 		assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
 	})
 	t.Run("authorization response limit", func(t *testing.T) {
-		provider := newTestProvider(t, helperExecutable(t, "oversized"), time.Second, 1<<20)
+		provider := newTestProvider(t, helperExecutable(t, "oversized"), 30*time.Second, 1<<20)
 		upload := newTestUpload(testPDF(2))
 		authorization := testAuthorization(provider.Descriptor(), upload.Metadata())
 		authorization.MaxTotalResultBytes = 1024
@@ -167,7 +167,7 @@ func TestProviderBoundsOutputAndSanitizesProcessFailure(t *testing.T) {
 		assertProviderCode(t, err, document.RenditionErrorMalformedEvidence)
 	})
 	t.Run("private stderr", func(t *testing.T) {
-		provider := newTestProvider(t, helperExecutable(t, "failure"), time.Second, 1<<20)
+		provider := newTestProvider(t, helperExecutable(t, "failure"), 30*time.Second, 1<<20)
 		upload := newTestUpload(testPDF(2))
 		_, err := provider.Render(t.Context(), upload,
 			testAuthorization(provider.Descriptor(), upload.Metadata()))
@@ -307,7 +307,7 @@ func assertProviderCode(t *testing.T, err error, want document.RenditionErrorCod
 	require.Error(t, err)
 	providerErr, ok := errors.AsType[*document.RenditionProviderError](err)
 	require.True(t, ok)
-	assert.Equal(t, want, providerErr.Code())
+	assert.Equal(t, want, providerErr.Code(), "%v", err)
 }
 
 type cancelWhenCheckedContext struct {

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -478,6 +478,90 @@ test.describe("Docbank web screenshots", () => {
     });
   });
 
+  test("loaded-page keyboard navigation and tag hotkey", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("docbank-theme", "dark");
+    });
+    let listingRequests = 0;
+    page.on("request", (request) => {
+      if (/\/api\/v1\/nodes\/\d+\/children\?/.test(request.url())) {
+        listingRequests += 1;
+      }
+    });
+    await page.goto(webURL, { waitUntil: "domcontentloaded" });
+    await page.addStyleTag({
+      content: `
+        *, *::before, *::after {
+          animation-duration: 0.001s !important;
+          animation-delay: 0s !important;
+          transition-duration: 0s !important;
+          caret-color: transparent !important;
+        }
+      `,
+    });
+
+    await page.getByRole("cell", { name: "Reports", exact: true }).dblclick();
+    const preceding = page.getByRole("cell", {
+      name: "résumé-日本語.txt",
+      exact: true,
+    });
+    await preceding.click();
+    await page.keyboard.press("j");
+    const supportingRow = page
+      .getByRole("row")
+      .filter({ has: page.getByRole("cell", { name: "supporting-schedule.csv" }) });
+    await expect(supportingRow).toHaveAttribute("aria-selected", "true");
+
+    const requestsAtBoundary = listingRequests;
+    await page.keyboard.press("j");
+    await expect(
+      page.getByRole("status", { name: "Keyboard shortcut status" }),
+    ).toContainText("Last loaded row reached.");
+    expect(listingRequests).toBe(requestsAtBoundary);
+
+    await page.keyboard.press("Space");
+    const dock = page.getByRole("region", { name: "Selected documents" });
+    await expect(dock).toContainText("1 selected on this page");
+    await page.keyboard.press("k");
+    await page.keyboard.press("j");
+    await expect(supportingRow).toBeFocused();
+    await expectFocusAboveDock(page, dock);
+
+    await page.keyboard.press("Shift+/");
+    const help = page.getByRole("dialog", { name: "Keyboard shortcuts" });
+    await expect(help).toBeVisible();
+    const firstTag = help.getByRole("combobox", {
+      name: "Tag shortcut 1: Unassigned",
+    });
+    await expect(firstTag).toBeEnabled();
+    await firstTag.click();
+    await help.getByRole("option", { name: "tax" }).click();
+    await help.getByRole("button", { name: "Done" }).click();
+
+    const receiptResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PUT" &&
+        /\/api\/v1\/nodes\/\d+\/tags\/[0-9a-f-]+$/.test(response.url()),
+    );
+    await page.keyboard.press("1");
+    const response = await receiptResponse;
+    expect(response.status()).toBe(200);
+    const receipt = (await response.json()) as {
+      changed?: unknown;
+      node?: { path?: unknown };
+      tag?: { name?: unknown };
+    };
+    expect(receipt.changed).toBe(true);
+    expect(receipt.node?.path).toBe("/Reports/supporting-schedule.csv");
+    expect(receipt.tag?.name).toBe("tax");
+    await expect(
+      page.getByRole("status", { name: "Keyboard shortcut status" }),
+    ).toContainText("Added tax to supporting-schedule.csv.");
+
+    await page.keyboard.press("Shift+/");
+    await expect(help.getByRole("combobox", { name: "Tag shortcut 1: tax" })).toBeVisible();
+  });
+
   test("trash confirmation", async ({ page }) => {
     await page.addInitScript(() => {
       localStorage.setItem("docbank-theme", "dark");

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
   import ActivityIcon from "@lucide/svelte/icons/activity";
   import ArchiveIcon from "@lucide/svelte/icons/archive";
   import ArrowLeftIcon from "@lucide/svelte/icons/arrow-left";
@@ -15,6 +15,7 @@
   import TagIcon from "@lucide/svelte/icons/tag";
   import TagsIcon from "@lucide/svelte/icons/tags";
   import HistoryIcon from "@lucide/svelte/icons/history";
+  import KeyboardIcon from "@lucide/svelte/icons/keyboard";
   import Trash2Icon from "@lucide/svelte/icons/trash-2";
   import UploadIcon from "@lucide/svelte/icons/upload";
   import {
@@ -32,6 +33,8 @@
     TableHeaderCell,
     ThemeToggle,
     TopBar,
+    createShortcutManager,
+    formatShortcutKeys,
     type SortDirection,
   } from "@kenn-io/kit-ui";
   import AuditEvidenceDrawer from "./AuditEvidenceDrawer.svelte";
@@ -45,6 +48,7 @@
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import SelectionDock from "./SelectionDock.svelte";
   import type { SelectionTarget } from "./selection.js";
+  import ShortcutHelpModal from "./ShortcutHelpModal.svelte";
   import StorageDrawer from "./StorageDrawer.svelte";
   import SavedQueriesDrawer from "./SavedQueriesDrawer.svelte";
   import { parseQuery, type Query } from "./query.js";
@@ -61,6 +65,7 @@
   import {
     APIError,
     auditStatusForNode,
+    changeNodeTag,
     children,
     liveTaggedNodes,
     nodeTags,
@@ -80,6 +85,7 @@
   import { basename, formatBytes, formatDate } from "./format.js";
   import { orderRows, reconcileSearchView, type SortField } from "./rows.js";
   import { sortTags } from "./tagPresentation.js";
+  import { isAppShortcutSuppressed, moveInspection } from "./shortcuts.js";
   import {
     clearSelection,
     reconcileSelection,
@@ -88,6 +94,14 @@
     toggleDocumentSelection,
     type SelectionState,
   } from "./selection.js";
+  import {
+    TAG_HOTKEYS,
+    isTagHotkeyVaultID,
+    loadTagHotkeys,
+    saveTagHotkeys,
+    type TagHotkey,
+    type TagHotkeyBindings,
+  } from "./tag-hotkeys.js";
   import { VerifiedUploadChannel } from "./upload.js";
 
   type Row = { node: Node; path: string; match?: "name" | "content" };
@@ -127,6 +141,13 @@
   let tagCatalogListed = $state(0);
   let tagCatalogLoading = $state(false);
   let tagCatalogError = $state("");
+  let vaultID = $state("");
+  let tagHotkeys = $state<TagHotkeyBindings>({});
+  let pendingTagHotkey = $state<TagHotkey | "">("");
+  let shortcutNotice = $state("");
+  let shortcutError = $state("");
+  let shortcutHelpOpen = $state(false);
+  let searchInputEl = $state<HTMLInputElement>();
   let selectedTags = $state<Tag[]>([]);
   let selectedTagsTotal = $state(0);
   let selectedTagsLoading = $state(false);
@@ -161,6 +182,7 @@
   let auditGeneration = 0;
   let tagGeneration = 0;
   let tagCatalogGeneration = 0;
+  let tagHotkeyGeneration = 0;
   let pendingSelectionRange = false;
 
   const selected = $derived(rows.find((row) => row.node.id === selectedID));
@@ -189,6 +211,54 @@
   onMount(() => {
     try { savedQueryDraft = queryFromFragment(location.hash); }
     catch (cause) { queryURLError = cause instanceof Error ? cause.message : String(cause); }
+    const shortcutManager = createShortcutManager();
+    const unregister = [
+      shortcutManager.register("/", focusSearch, {
+        description: "Focus search",
+      }),
+      shortcutManager.register("j", () => void inspectRelative(1), {
+        description: "Inspect next loaded row",
+      }),
+      shortcutManager.register("k", () => void inspectRelative(-1), {
+        description: "Inspect previous loaded row",
+      }),
+      shortcutManager.register("space", toggleInspectedSelection, {
+        description: "Toggle inspected file selection",
+      }),
+      shortcutManager.register("enter", activateInspected, {
+        description: "Open inspected row",
+      }),
+      shortcutManager.register("escape", clearShortcutSelection, {
+        description: "Clear page selection",
+      }),
+      shortcutManager.register("shift+/", openShortcutHelp, {
+        description: "Show keyboard shortcuts",
+      }),
+      ...TAG_HOTKEYS.map((key) =>
+        shortcutManager.register(
+          key,
+          (event) => void toggleInspectedTag(key, event),
+          { description: `Toggle configured tag ${key}` },
+        ),
+      ),
+    ];
+    const handleShortcut = (event: KeyboardEvent): void => {
+      if (
+        isAppShortcutSuppressed(
+          event,
+          !webSession || loading || searchPending,
+        )
+      ) {
+        return;
+      }
+      shortcutManager.handleKeydown(event);
+    };
+    window.addEventListener("keydown", handleShortcut);
+    const detachShortcuts = (): void => {
+      window.removeEventListener("keydown", handleShortcut);
+      unregister.forEach((remove) => remove());
+    };
+
     const session = takeFragmentSession();
     if (savedQueryDraft) replaceQueryURL(savedQueryDraft);
     if (session) {
@@ -211,13 +281,200 @@
           uploadChannelError = cause instanceof Error ? cause.message : String(cause);
         },
       );
-      return () => channel.close();
+      return () => {
+        channel.close();
+        detachShortcuts();
+      };
     }
+    return detachShortcuts;
   });
 
   function clearBulkSelection(): void {
     bulkSelection = clearSelection();
     pendingSelectionRange = false;
+  }
+
+  function invalidateTagHotkeyMutation(): void {
+    tagHotkeyGeneration += 1;
+    pendingTagHotkey = "";
+  }
+
+  function localPreferenceStorage(): Storage | undefined {
+    try {
+      return globalThis.localStorage;
+    } catch {
+      return undefined;
+    }
+  }
+
+  function clearShortcutFeedback(): void {
+    shortcutNotice = "";
+    shortcutError = "";
+  }
+
+  function focusSearch(): void {
+    clearShortcutFeedback();
+    searchInputEl?.focus();
+  }
+
+  async function revealInspectedRow(nodeID: number): Promise<void> {
+    await tick();
+    const row = document.querySelector<HTMLElement>(`tr[data-node-id="${nodeID}"]`);
+    if (!row) return;
+    row.focus({ preventScroll: true });
+    row.scrollIntoView({ block: "nearest" });
+    const dock = document.querySelector<HTMLElement>(".selection-dock");
+    const scroller = row.closest<HTMLElement>(".kit-table-wrapper");
+    if (!dock || !scroller) return;
+    const rowBounds = row.getBoundingClientRect();
+    const dockBounds = dock.getBoundingClientRect();
+    const overlap = rowBounds.bottom - dockBounds.top;
+    if (overlap > 0) scroller.scrollBy({ top: overlap + 8, behavior: "auto" });
+  }
+
+  async function inspectRelative(direction: -1 | 1): Promise<void> {
+    clearShortcutFeedback();
+    const move = moveInspection(
+      sortedRows.map((row) => ({ id: row.node.id })),
+      selectedID,
+      direction,
+    );
+    if (move.boundary === "empty") {
+      shortcutNotice = "No rows are loaded.";
+      return;
+    }
+    if (move.id !== undefined && move.id !== selectedID) selectNode(move.id);
+    if (move.id !== undefined) await revealInspectedRow(move.id);
+    if (move.boundary === "first") shortcutNotice = "First loaded row reached.";
+    else if (move.boundary === "last") shortcutNotice = "Last loaded row reached.";
+  }
+
+  function toggleInspectedSelection(): void {
+    clearShortcutFeedback();
+    if (!selected) {
+      shortcutNotice = "No row is inspected.";
+      return;
+    }
+    if (selected.node.kind !== "file") {
+      shortcutNotice = "The inspected row is a folder; only files can be selected.";
+      return;
+    }
+    toggleBulkSelection(
+      selected,
+      !bulkSelection.selectedIDs.has(selected.node.id),
+    );
+  }
+
+  function activateInspected(): void {
+    clearShortcutFeedback();
+    if (!selected) {
+      shortcutNotice = "No row is inspected.";
+      return;
+    }
+    activate(selected);
+  }
+
+  function clearShortcutSelection(): void {
+    clearShortcutFeedback();
+    clearBulkSelection();
+    shortcutNotice = "Page selection cleared.";
+  }
+
+  function openShortcutHelp(): void {
+    clearShortcutFeedback();
+    shortcutHelpOpen = true;
+  }
+
+  function changeTagHotkeyBinding(key: TagHotkey, tagID: string): void {
+    if (!vaultID) return;
+    const next = { ...tagHotkeys };
+    if (tagID) next[key] = tagID;
+    else delete next[key];
+    const storage = localPreferenceStorage();
+    if (!storage || !saveTagHotkeys(storage, vaultID, next)) {
+      shortcutError = "This browser blocked saving tag shortcut preferences.";
+      return;
+    }
+    tagHotkeys = next;
+    clearShortcutFeedback();
+    shortcutNotice = tagID
+      ? `Tag shortcut ${key} saved for this vault.`
+      : `Tag shortcut ${key} cleared for this vault.`;
+  }
+
+  async function toggleInspectedTag(
+    key: TagHotkey,
+    event: KeyboardEvent,
+  ): Promise<void> {
+    if (event.repeat || pendingTagHotkey) return;
+    clearShortcutFeedback();
+    const tagID = tagHotkeys[key];
+    if (!tagID) {
+      shortcutNotice = `No tag is assigned to shortcut ${key}.`;
+      return;
+    }
+    const target = selected;
+    if (!target || target.node.kind !== "file") {
+      shortcutNotice = "Inspect a file before using a tag shortcut.";
+      return;
+    }
+    const tag = tagCatalog.find((item) => item.id === tagID);
+    if (!tag) {
+      shortcutNotice = `Tag shortcut ${key} is unavailable because its saved tag is not in the loaded catalog.`;
+      return;
+    }
+    if (
+      selectedTagsLoading ||
+      Boolean(selectedTagsError) ||
+      selectedTagsTotal !== selectedTags.length
+    ) {
+      shortcutNotice = "Tag shortcuts are unavailable until all assigned tags for this file are known.";
+      return;
+    }
+
+    const session = webSession;
+    const expectedNodeID = target.node.id;
+    const expectedRevision = target.node.revision;
+    const assigned = selectedTags.some((item) => item.id === tagID);
+    const request = ++tagHotkeyGeneration;
+    pendingTagHotkey = key;
+    try {
+      const receipt = await changeNodeTag(
+        session,
+        expectedNodeID,
+        expectedRevision,
+        tagID,
+        !assigned,
+      );
+      const current = rows.find((row) => row.node.id === expectedNodeID);
+      if (
+        request !== tagHotkeyGeneration ||
+        session !== webSession ||
+        selectedID !== expectedNodeID ||
+        current?.node.revision !== expectedRevision
+      ) {
+        return;
+      }
+      handleTagChanged(receipt, !assigned);
+      shortcutNotice = assigned
+        ? `Removed ${receipt.tag.name} from ${target.node.name}.`
+        : `Added ${receipt.tag.name} to ${target.node.name}.`;
+    } catch (cause) {
+      if (
+        request !== tagHotkeyGeneration ||
+        session !== webSession ||
+        selectedID !== expectedNodeID
+      ) {
+        return;
+      }
+      if (cause instanceof APIError && cause.status === 401) {
+        handleFailure(cause);
+        return;
+      }
+      shortcutError = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (request === tagHotkeyGeneration) pendingTagHotkey = "";
+    }
   }
 
   function replaceRows(nextRows: Row[], reconcile: boolean): void {
@@ -268,11 +525,15 @@
       backupsOpen = false;
       trashOpen = false;
       tagCatalogOpen = false;
+      shortcutHelpOpen = false;
       uploadTarget = null;
       trashTarget = null;
       tagCatalog = [];
       tagCatalogListed = 0;
       tagCatalogLoading = false;
+      vaultID = "";
+      tagHotkeys = {};
+      invalidateTagHotkeyMutation();
       selectedTags = [];
       selectedTagsTotal = 0;
       searchPending = false;
@@ -284,6 +545,7 @@
   }
 
   async function loadRoot(): Promise<void> {
+    invalidateTagHotkeyMutation();
     clearBulkSelection();
     const request = ++generation;
     const session = webSession;
@@ -306,6 +568,7 @@
     preferredSelectedID?: number,
     preserveSort = false,
   ): Promise<void> {
+    invalidateTagHotkeyMutation();
     const refreshing = !remember && directory?.id === nodeID && !activeQuery && !activeTagID;
     const request = ++generation;
     searchPending = false;
@@ -372,6 +635,7 @@
   }
 
   async function runSearch(preferredSelectedID = selectedID): Promise<void> {
+    invalidateTagHotkeyMutation();
     const query = searchQuery.trim();
     if (!query) {
       if (tagFilterID) await loadTaggedNodes(tagFilterID);
@@ -427,6 +691,7 @@
     tagID: string,
     preferredSelectedID?: number,
   ): Promise<void> {
+    invalidateTagHotkeyMutation();
     if (!directory) return;
     const request = ++generation;
     const refreshing = activeQuery === "" && activeTagID === tagID;
@@ -465,6 +730,7 @@
   }
 
   function goBack(): void {
+    invalidateTagHotkeyMutation();
     generation += 1;
     searchPending = false;
     const previous = stack.at(-1);
@@ -518,7 +784,9 @@
   }
 
   function selectNode(nodeID: number | undefined): void {
+    if (selectedID === nodeID && pendingTagHotkey) return;
     if (selectedID !== nodeID) {
+      invalidateTagHotkeyMutation();
       historyOpen = false;
       versionsOpen = false;
       provenanceOpen = false;
@@ -531,7 +799,7 @@
     auditError = "";
     auditGeneration += 1;
     tagGeneration += 1;
-    if (nodeID !== undefined && webSession) void loadAuditStatus(nodeID);
+    if (webSession) void loadAuditStatus(nodeID);
     if (nodeID !== undefined && webSession) void loadSelectedTags(nodeID);
   }
 
@@ -614,7 +882,7 @@
     }
   }
 
-  async function loadAuditStatus(nodeID: number): Promise<void> {
+  async function loadAuditStatus(nodeID?: number): Promise<void> {
     const request = ++auditGeneration;
     const session = webSession;
     auditLoading = true;
@@ -622,6 +890,16 @@
       const status = await auditStatusForNode(session, nodeID);
       if (request !== auditGeneration || session !== webSession || selectedID !== nodeID) return;
       selectedAudit = status;
+      if (isTagHotkeyVaultID(status.vault_id)) {
+        if (vaultID !== status.vault_id) {
+          vaultID = status.vault_id;
+          const storage = localPreferenceStorage();
+          tagHotkeys = storage ? loadTagHotkeys(storage, vaultID) : {};
+        }
+      } else {
+        vaultID = "";
+        tagHotkeys = {};
+      }
     } catch (cause) {
       if (request !== auditGeneration || session !== webSession || selectedID !== nodeID) return;
       if (cause instanceof APIError && cause.status === 401) {
@@ -857,6 +1135,7 @@
     auditGeneration += 1;
     tagGeneration += 1;
     tagCatalogGeneration += 1;
+    invalidateTagHotkeyMutation();
     const session = webSession;
     uploadChannel?.close();
     uploadChannel = null;
@@ -875,6 +1154,10 @@
     tagCatalogListed = 0;
     tagCatalogLoading = false;
     tagCatalogError = "";
+    vaultID = "";
+    tagHotkeys = {};
+    shortcutNotice = "";
+    shortcutError = "";
     auditLoading = false;
     auditError = "";
     historyOpen = false;
@@ -888,6 +1171,7 @@
     manageTagsTarget = null;
     batchTagsTargets = null;
     tagCatalogOpen = false;
+    shortcutHelpOpen = false;
     uploadTarget = null;
     trashTarget = null;
     activeQuery = "";
@@ -965,8 +1249,10 @@
         >
           <SearchInput
             bind:value={searchQuery}
+            bind:inputEl={searchInputEl}
             placeholder="Search names and extracted text"
             ariaLabel="Search documents"
+            keys={formatShortcutKeys("/")}
             block
             onclear={clearSearch}
           />
@@ -1062,6 +1348,14 @@
           }}
         >
           <ShieldCheckIcon size="14" aria-hidden="true" />
+        </IconButton>
+        <IconButton
+          size="sm"
+          ariaLabel="Keyboard shortcuts and tag hotkeys"
+          title="Keyboard shortcuts and tag hotkeys (?)"
+          onclick={openShortcutHelp}
+        >
+          <KeyboardIcon size="14" aria-hidden="true" />
         </IconButton>
         <ThemeToggle size="sm" />
         <IconButton size="sm" ariaLabel="Lock web session" onclick={() => void lock()}>
@@ -1187,6 +1481,21 @@
         {#if error}
           <div class="banner error" role="alert">{error}</div>
         {/if}
+        {#if shortcutError}
+          <div class="banner error" role="alert" aria-label="Keyboard shortcut error">
+            {shortcutError}
+          </div>
+        {/if}
+        {#if shortcutNotice}
+          <div
+            class="banner shortcut-notice"
+            role="status"
+            aria-live="polite"
+            aria-label="Keyboard shortcut status"
+          >
+            {shortcutNotice}
+          </div>
+        {/if}
         {#if loading}
           <div class="loading"><Spinner size={16} /> Loading vault…</div>
         {:else if rows.length === 0}
@@ -1252,12 +1561,17 @@
               {#each sortedRows as row (row.node.id)}
                 <tr
                   class:selected={row.node.id === selectedID}
+                  data-node-id={row.node.id}
                   tabindex="0"
                   aria-selected={row.node.id === selectedID}
                   ondblclick={() => activate(row)}
                   onclick={() => selectNode(row.node.id)}
                   onkeydown={(event) => {
-                    if (event.key === "Enter") activate(row);
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      activate(row);
+                    }
                   }}
                 >
                   <td
@@ -1362,7 +1676,7 @@
                       size="sm"
                       tone="info"
                       surface="soft"
-                      disabled={loading || selectedTagsLoading || selectedTagsError !== ""}
+                      disabled={loading || selectedTagsLoading || selectedTagsError !== "" || pendingTagHotkey !== ""}
                       onclick={() => {
                         if (!loading && selected) manageTagsTarget = selected;
                       }}
@@ -1561,8 +1875,18 @@
         onclear={clearBulkSelection}
         onselectvisible={() => selectAllVisibleDocuments()}
         ontags={() => openBatchTags(bulkTargets)}
-        tagsDisabled={loading}
+        tagsDisabled={loading || pendingTagHotkey !== ""}
         oncsv={exportPageCSV}
+      />
+    {/if}
+    {#if shortcutHelpOpen}
+      <ShortcutHelpModal
+        vaultReady={vaultID !== ""}
+        catalog={tagCatalog}
+        catalogTotal={tagCatalogTotal}
+        bindings={tagHotkeys}
+        onbindingchange={changeTagHotkeyBinding}
+        onclose={() => (shortcutHelpOpen = false)}
       />
     {/if}
     {#if historyOpen && selected && membership?.protected}
@@ -1712,5 +2036,10 @@
   :global(.browser th.selection-column) {
     background: var(--bg-inset);
     border-bottom: 1px solid var(--border-default);
+  }
+
+  .shortcut-notice {
+    border-bottom: 1px solid var(--border-muted);
+    background: var(--bg-inset);
   }
 </style>

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1311,3 +1311,439 @@ it("retains tag selection on refresh and clears it when the tag disappears", asy
   await screen.findByRole("cell", { name: "readme.txt" });
   expect(screen.queryByText(/selected on this page/)).toBeNull();
 });
+
+const keyboardVaultID = "11111111-1111-4111-8111-111111111111";
+const keyboardTagID = "33333333-3333-4333-8333-333333333333";
+const keyboardReviewedTagID = "44444444-4444-4444-8444-444444444444";
+
+function prepareKeyboardApp(): Storage {
+  prepareSelectionApp();
+  const entries = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key) => entries.get(key) ?? null,
+    key: (index) => [...entries.keys()][index] ?? null,
+    removeItem: (key) => entries.delete(key),
+    setItem: (key, value) => entries.set(key, value),
+  };
+  vi.stubGlobal("localStorage", storage);
+  return storage;
+}
+
+function installKeyboardBackend(
+  mutation: "success" | "stale" | "pending" | "same-node-race" = "success",
+  empty = false,
+) {
+  const root = selectionNode(1, "", "dir", undefined);
+  const reports = selectionNode(20, "Reports", "dir", 1);
+  const zeta = selectionNode(10, "zeta.txt", "file", 1, 3);
+  const alpha = selectionNode(30, "alpha.txt", "file", 1, 5);
+  const tax = {
+    id: keyboardTagID,
+    name: "tax",
+    revision: 2,
+    assignment_count: 0,
+  };
+  const reviewed = {
+    id: keyboardReviewedTagID,
+    name: "reviewed",
+    revision: 1,
+    assignment_count: 1,
+  };
+  const json = (value: unknown, status = 200) =>
+    new Response(JSON.stringify(value), {
+      status,
+      headers: {
+        "Content-Type": status >= 400 ? "application/problem+json" : "application/json",
+      },
+    });
+  let reportsReads = 0;
+  let rootReads = 0;
+  let tagReads = 0;
+  const writes: Array<{ url: string; method: string; revision: string | null }> = [];
+  let resolveMutation: ((response: Response) => void) | undefined;
+  const delayedMutation = new Promise<Response>((resolve) => {
+    resolveMutation = resolve;
+  });
+  let resolveTagReload: ((response: Response) => void) | undefined;
+  const delayedTagReload = new Promise<Response>((resolve) => {
+    resolveTagReload = resolve;
+  });
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/v1/path?path=%2F") return json(root);
+    if (url === "/api/v1/nodes/1/children?limit=1000&offset=0") {
+      rootReads += 1;
+      return json({
+        directory: root,
+        items: empty ? [] : [zeta, reports, alpha],
+        total: empty ? 0 : 4,
+        limit: 1000,
+        offset: 0,
+      });
+    }
+    if (url === "/api/v1/nodes/20/children?limit=1000&offset=0") {
+      reportsReads += 1;
+      return json({
+        directory: reports,
+        items: [],
+        total: 0,
+        limit: 1000,
+        offset: 0,
+      });
+    }
+    if (url === "/api/v1/tags?limit=1000&offset=0") {
+      const items = mutation === "same-node-race" ? [tax, reviewed] : [tax];
+      return json({ items, total: items.length, limit: 1000, offset: 0 });
+    }
+    if (url === "/api/v1/audit/status" || url.startsWith("/api/v1/audit/status?node_id=")) {
+      return json({
+        enabled: false,
+        vault_id: keyboardVaultID,
+        operation_sequence_high_water: 0,
+        allocation_entry_count: 0,
+        scopes: [],
+      });
+    }
+    if (/^\/api\/v1\/nodes\/\d+\/tags\?limit=1000&offset=0$/.test(url)) {
+      tagReads += 1;
+      if (mutation === "same-node-race") {
+        if (tagReads === 1) {
+          return json({ items: [reviewed], total: 1, limit: 1000, offset: 0 });
+        }
+        return delayedTagReload;
+      }
+      return json({ items: [], total: 0, limit: 1000, offset: 0 });
+    }
+    if (
+      url === `/api/v1/nodes/10/tags/${keyboardTagID}` &&
+      init?.method === "PUT"
+    ) {
+      writes.push({
+        url,
+        method: init.method,
+        revision: new Headers(init.headers).get("If-Match"),
+      });
+      if (mutation === "pending" || mutation === "same-node-race") {
+        return delayedMutation;
+      }
+      if (mutation === "stale") {
+        return json(
+          {
+            status: 412,
+            code: "stale_revision",
+            detail: "node changed; refresh before using this tag shortcut",
+          },
+          412,
+        );
+      }
+      return json({
+        tag: { ...tax, revision: 3, assignment_count: 1 },
+        node: {
+          ...zeta,
+          revision: 4,
+          path: "/zeta.txt",
+          modified_at: "2026-09-09T00:01:00Z",
+        },
+        changed: true,
+      });
+    }
+    if (
+      mutation === "same-node-race" &&
+      url === `/api/v1/nodes/10/tags/${keyboardReviewedTagID}`
+    ) {
+      writes.push({
+        url,
+        method: init?.method ?? "",
+        revision: new Headers(init?.headers).get("If-Match"),
+      });
+      return json({
+        tag: { ...reviewed, revision: 2, assignment_count: 0 },
+        node: {
+          ...zeta,
+          revision: 5,
+          path: "/zeta.txt",
+          modified_at: "2026-09-09T00:02:00Z",
+        },
+        changed: true,
+      });
+    }
+    if (url === "/api/daemon/web-session" && init?.method === "DELETE") {
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  });
+
+  return {
+    alpha,
+    tax,
+    writes,
+    getRootReads: () => rootReads,
+    getReportsReads: () => reportsReads,
+    getTagReads: () => tagReads,
+    resolveMutation: () =>
+      resolveMutation?.(
+        json({
+          tag: { ...tax, revision: 3, assignment_count: 1 },
+          node: {
+            ...zeta,
+            revision: 4,
+            path: "/zeta.txt",
+            modified_at: "2026-09-09T00:01:00Z",
+          },
+          changed: true,
+        }),
+      ),
+    resolveTagReload: () =>
+      resolveTagReload?.(
+        json({
+          items: [reviewed, { ...tax, revision: 3, assignment_count: 1 }],
+          total: 2,
+          limit: 1000,
+          offset: 0,
+        }),
+      ),
+  };
+}
+
+async function configureFirstTagHotkey(): Promise<void> {
+  await fireEvent.click(
+    screen.getByRole("button", { name: "Keyboard shortcuts and tag hotkeys" }),
+  );
+  const slot = screen.getByRole("combobox", {
+    name: "Tag shortcut 1: Unassigned",
+  });
+  await waitFor(() => expect(slot.hasAttribute("disabled")).toBe(false));
+  await fireEvent.click(slot);
+  await fireEvent.click(screen.getByRole("option", { name: "tax" }));
+  await fireEvent.click(screen.getByRole("button", { name: "Done" }));
+}
+
+it("navigates the displayed page, keeps checkbox selection independent, and activates a row once", async () => {
+  prepareKeyboardApp();
+  const backend = installKeyboardBackend();
+  render(App);
+
+  await screen.findByRole("cell", { name: "alpha.txt" });
+  await screen.findByLabelText("Document authority for zeta.txt");
+  const requestsAtBoundary = backend.getRootReads();
+
+  await fireEvent.keyDown(window, { key: "k" });
+  expect(screen.getByLabelText("Document authority for alpha.txt")).toBeTruthy();
+  await fireEvent.keyDown(window, { key: " " });
+  expect(
+    (screen.getByRole("checkbox", {
+      name: "Select alpha.txt",
+    }) as HTMLInputElement).checked,
+  ).toBe(true);
+  expect(screen.getByLabelText("Document authority for alpha.txt")).toBeTruthy();
+
+  await fireEvent.keyDown(window, { key: "k" });
+  expect(screen.getByLabelText("Folder for Reports")).toBeTruthy();
+  await fireEvent.keyDown(window, { key: "k" });
+  expect(
+    (await screen.findByRole("status", {
+      name: "Keyboard shortcut status",
+    })).textContent,
+  ).toContain(
+    "First loaded row reached.",
+  );
+  expect(backend.getRootReads()).toBe(requestsAtBoundary);
+
+  await fireEvent.keyDown(window, { key: "j" });
+  expect(screen.getByLabelText("Document authority for alpha.txt")).toBeTruthy();
+  await fireEvent.keyDown(window, { key: "Escape" });
+  expect(screen.queryByText(/selected on this page/)).toBeNull();
+
+  await fireEvent.keyDown(window, { key: "/", shiftKey: true });
+  expect(screen.getByRole("dialog", { name: "Keyboard shortcuts" })).toBeTruthy();
+  await fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+  await fireEvent.keyDown(window, { key: "?", shiftKey: true });
+  expect(screen.getByRole("dialog", { name: "Keyboard shortcuts" })).toBeTruthy();
+  await fireEvent.click(screen.getByRole("button", { name: "Done" }));
+
+  await fireEvent.keyDown(window, { key: "/" });
+  expect(document.activeElement).toBe(
+    screen.getByRole("searchbox", { name: "Search documents" }),
+  );
+  await fireEvent.keyDown(document.activeElement!, { key: "j" });
+  expect(screen.getByLabelText("Document authority for alpha.txt")).toBeTruthy();
+
+  const reportsRow = screen.getByRole("cell", { name: "Reports" }).closest("tr")!;
+  reportsRow.focus();
+  await fireEvent.keyDown(reportsRow, { key: "Enter" });
+  await waitFor(() => expect(backend.getReportsReads()).toBe(1));
+});
+
+it("persists a vault-scoped tag binding and applies it only to the inspected file", async () => {
+  const storage = prepareKeyboardApp();
+  const backend = installKeyboardBackend();
+  render(App);
+
+  await screen.findByRole("cell", { name: "zeta.txt" });
+  await configureFirstTagHotkey();
+  await fireEvent.click(screen.getByRole("checkbox", { name: "Select alpha.txt" }));
+  await fireEvent.keyDown(window, { key: "1" });
+
+  await waitFor(() => expect(backend.writes).toHaveLength(1));
+  expect(backend.writes[0]).toEqual({
+    url: `/api/v1/nodes/10/tags/${keyboardTagID}`,
+    method: "PUT",
+    revision: "3",
+  });
+  expect(await screen.findByText("Added tax to zeta.txt.")).toBeTruthy();
+  expect(screen.getByText("1 selected on this page")).toBeTruthy();
+  expect(storage.getItem(`docbank:tag-hotkeys:v1:${keyboardVaultID}`)).toBe(
+    JSON.stringify({ version: 1, bindings: { "1": keyboardTagID } }),
+  );
+});
+
+it("loads and edits tag bindings in an empty vault", async () => {
+  const storage = prepareKeyboardApp();
+  const key = `docbank:tag-hotkeys:v1:${keyboardVaultID}`;
+  storage.setItem(key, JSON.stringify({ version: 1, bindings: { "1": keyboardTagID } }));
+  installKeyboardBackend("success", true);
+  render(App);
+
+  await fireEvent.click(
+    screen.getByRole("button", { name: "Keyboard shortcuts and tag hotkeys" }),
+  );
+  const slot = await screen.findByRole("combobox", { name: "Tag shortcut 1: tax" });
+  expect(slot.hasAttribute("disabled")).toBe(false);
+  await fireEvent.click(slot);
+  await fireEvent.click(screen.getByRole("option", { name: "Unassigned" }));
+  expect(storage.getItem(key)).toBe(JSON.stringify({ version: 1, bindings: {} }));
+});
+
+it("shows stale tag conflicts without retrying", async () => {
+  prepareKeyboardApp();
+  const backend = installKeyboardBackend("stale");
+  render(App);
+
+  await screen.findByRole("cell", { name: "zeta.txt" });
+  await configureFirstTagHotkey();
+  await fireEvent.keyDown(window, { key: "1" });
+
+  expect(
+    await screen.findByText("node changed; refresh before using this tag shortcut"),
+  ).toBeTruthy();
+  expect(backend.writes).toHaveLength(1);
+});
+
+it("waits for a pending tag shortcut before opening tag editors with updated tags", async () => {
+  prepareKeyboardApp();
+  const backend = installKeyboardBackend("pending");
+  render(App);
+
+  await screen.findByRole("cell", { name: "zeta.txt" });
+  await configureFirstTagHotkey();
+  const manage = screen.getByRole("button", { name: "Manage" });
+  await fireEvent.click(screen.getByRole("checkbox", { name: "Select zeta.txt" }));
+  const editTags = screen.getByRole("button", { name: "Edit tags" });
+  await fireEvent.keyDown(window, { key: "1" });
+  expect(editTags.hasAttribute("disabled")).toBe(true);
+  editTags.click();
+  expect(screen.queryByRole("dialog", { name: "Tag selected documents" })).toBeNull();
+  expect(manage.hasAttribute("disabled")).toBe(true);
+  manage.click();
+  expect(screen.queryByRole("dialog", { name: "Manage tags for zeta.txt" })).toBeNull();
+
+  backend.resolveMutation();
+  await screen.findByText("Added tax to zeta.txt.");
+  expect(editTags.hasAttribute("disabled")).toBe(false);
+  expect(manage.hasAttribute("disabled")).toBe(false);
+  await fireEvent.click(manage);
+  expect(await screen.findByRole("button", { name: "Remove tag tax" })).toBeTruthy();
+});
+
+it("suppresses repeated pending tag writes and discards completion after selection changes", async () => {
+  prepareKeyboardApp();
+  const backend = installKeyboardBackend("pending");
+  render(App);
+
+  await screen.findByRole("cell", { name: "zeta.txt" });
+  await configureFirstTagHotkey();
+  await fireEvent.keyDown(window, { key: "1" });
+  await fireEvent.keyDown(window, { key: "1", repeat: true });
+  await fireEvent.keyDown(window, { key: "1" });
+  expect(backend.writes).toHaveLength(1);
+
+  await fireEvent.keyDown(window, { key: "k" });
+  expect(screen.getByLabelText("Document authority for alpha.txt")).toBeTruthy();
+  backend.resolveMutation();
+  await Promise.resolve();
+  expect(screen.queryByText("Added tax to zeta.txt.")).toBeNull();
+  expect(screen.getByLabelText("Document authority for alpha.txt")).toBeTruthy();
+});
+
+it("discards pending tag completion after the session is locked", async () => {
+  prepareKeyboardApp();
+  const backend = installKeyboardBackend("pending");
+  render(App);
+
+  await screen.findByRole("cell", { name: "zeta.txt" });
+  await configureFirstTagHotkey();
+  await fireEvent.keyDown(window, { key: "1" });
+  await fireEvent.click(screen.getByRole("button", { name: "Lock web session" }));
+  expect(await screen.findByText("Open your Docbank")).toBeTruthy();
+  backend.resolveMutation();
+  await Promise.resolve();
+  expect(screen.queryByText("Added tax to zeta.txt.")).toBeNull();
+  expect(backend.writes).toHaveLength(1);
+});
+
+it.each(["click", "Enter"] as const)(
+  "keeps complete tag observations when %s reactivates the inspected row during a pending tag write",
+  async (interaction) => {
+    const storage = prepareKeyboardApp();
+    storage.setItem(
+      `docbank:tag-hotkeys:v1:${keyboardVaultID}`,
+      JSON.stringify({
+        version: 1,
+        bindings: {
+          "1": keyboardTagID,
+          "2": keyboardReviewedTagID,
+        },
+      }),
+    );
+    const backend = installKeyboardBackend("same-node-race");
+    render(App);
+
+    const nameCell = await screen.findByRole("cell", { name: "zeta.txt" });
+    await waitFor(() =>
+      expect(screen.getByRole("group", { name: "Assigned tags" }).textContent).toContain(
+        "reviewed",
+      ),
+    );
+    await fireEvent.keyDown(window, { key: "1" });
+    expect(backend.writes).toEqual([
+      {
+        url: `/api/v1/nodes/10/tags/${keyboardTagID}`,
+        method: "PUT",
+        revision: "3",
+      },
+    ]);
+
+    const row = nameCell.closest("tr")!;
+    if (interaction === "click") await fireEvent.click(nameCell);
+    else await fireEvent.keyDown(row, { key: "Enter" });
+    backend.resolveMutation();
+    await screen.findByText("Added tax to zeta.txt.");
+    backend.resolveTagReload();
+    await Promise.resolve();
+
+    await fireEvent.keyDown(window, { key: "2" });
+    await waitFor(() => expect(backend.writes).toHaveLength(2));
+    expect(backend.writes[1]).toEqual({
+      url: `/api/v1/nodes/10/tags/${keyboardReviewedTagID}`,
+      method: "DELETE",
+      revision: "4",
+    });
+    expect(backend.getTagReads()).toBe(1);
+  },
+  );

--- a/frontend/src/ShortcutHelpModal.svelte
+++ b/frontend/src/ShortcutHelpModal.svelte
@@ -1,0 +1,235 @@
+<script lang="ts">
+  import {
+    Button,
+    KbdBadge,
+    Modal,
+    SelectDropdown,
+    formatShortcutKeys,
+    type SelectDropdownOption,
+  } from "@kenn-io/kit-ui";
+  import type { Tag } from "./api.js";
+  import {
+    TAG_HOTKEYS,
+    type TagHotkey,
+    type TagHotkeyBindings,
+  } from "./tag-hotkeys.js";
+
+  interface Props {
+    vaultReady: boolean;
+    catalog: Tag[];
+    catalogTotal: number;
+    bindings: TagHotkeyBindings;
+    onbindingchange: (key: TagHotkey, tagID: string) => void;
+    onclose: () => void;
+  }
+
+  let {
+    vaultReady,
+    catalog,
+    catalogTotal,
+    bindings,
+    onbindingchange,
+    onclose,
+  }: Props = $props();
+
+  const shortcuts = [
+    { combo: "/", action: "Focus search" },
+    { combo: "j", action: "Next loaded row" },
+    { combo: "k", action: "Previous loaded row" },
+    { combo: "space", action: "Toggle inspected file selection" },
+    { combo: "enter", action: "Open inspected row" },
+    { combo: "escape", action: "Clear page selection" },
+    { combo: "?", action: "Show keyboard shortcuts" },
+  ];
+
+  function optionsFor(key: TagHotkey): SelectDropdownOption[] {
+    const value = bindings[key] ?? "";
+    const options: SelectDropdownOption[] = [
+      { value: "", label: "Unassigned" },
+    ];
+    if (value && !catalog.some((tag) => tag.id === value)) {
+      options.push({
+        value,
+        label:
+          catalogTotal > catalog.length
+            ? `Not in loaded catalog · ${value}`
+            : `Unavailable or deleted tag · ${value}`,
+      });
+    }
+    options.push(
+      ...catalog.map((tag) => ({
+        value: tag.id,
+        label: tag.name,
+      })),
+    );
+    return options;
+  }
+</script>
+
+<Modal
+  title="Keyboard shortcuts"
+  tone="info"
+  width="680px"
+  maxWidth="min(680px, calc(100vw - 32px))"
+  ariaLabel="Keyboard shortcuts"
+  {onclose}
+>
+  <div class="shortcut-help">
+    <section aria-labelledby="browsing-shortcuts-heading">
+      <div class="section-heading">
+        <span>BROWSING</span>
+        <strong id="browsing-shortcuts-heading">Loaded-page shortcuts</strong>
+      </div>
+      <dl class="shortcut-list">
+        {#each shortcuts as shortcut (shortcut.combo)}
+          <div>
+            <dt>{shortcut.action}</dt>
+            <dd><KbdBadge keys={formatShortcutKeys(shortcut.combo)} /></dd>
+          </div>
+        {/each}
+      </dl>
+      <p class="boundary">
+        Row navigation stops at the first and last item currently loaded. It
+        does not wrap or fetch another page.
+      </p>
+    </section>
+
+    <section aria-labelledby="tag-shortcuts-heading">
+      <div class="section-heading">
+        <span>TAG HOTKEYS</span>
+        <strong id="tag-shortcuts-heading">Assign digits to vault tags</strong>
+      </div>
+      <p class="boundary">
+        Bindings stay in this browser for the current daemon run. Set them again
+        after restarting the daemon or clearing browser data.
+      </p>
+      {#if !vaultReady}
+        <p class="unavailable" role="status">
+          Tag shortcuts are unavailable until this browser session confirms the vault identity.
+        </p>
+      {/if}
+      <div class="tag-bindings">
+        {#each TAG_HOTKEYS as key (key)}
+          <div class="tag-binding">
+            <KbdBadge keys={formatShortcutKeys(key)} ariaLabel={`Digit ${key}`} />
+            <SelectDropdown
+              value={bindings[key] ?? ""}
+              options={optionsFor(key)}
+              title={`Tag shortcut ${key}`}
+              disabled={!vaultReady}
+              onchange={(tagID) => onbindingchange(key, tagID)}
+            />
+          </div>
+        {/each}
+      </div>
+      {#if catalogTotal > catalog.length}
+        <p class="boundary">
+          Showing the first {catalog.length} of {catalogTotal} tag definitions.
+          Saved IDs outside this loaded catalog are retained as unavailable.
+        </p>
+      {/if}
+    </section>
+  </div>
+  {#snippet footer()}
+    <Button surface="soft" onclick={onclose}>Done</Button>
+  {/snippet}
+</Modal>
+
+<style>
+  .shortcut-help {
+    display: grid;
+    gap: var(--space-6);
+  }
+
+  section {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .section-heading {
+    display: grid;
+    gap: var(--space-1);
+  }
+
+  .section-heading span {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold, 600);
+    letter-spacing: var(--letter-spacing-label, 0.08em);
+  }
+
+  .section-heading strong {
+    color: var(--text-primary);
+    font-size: var(--font-size-md);
+  }
+
+  .shortcut-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1px;
+    margin: 0;
+    overflow: hidden;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--border-muted);
+  }
+
+  .shortcut-list > div {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-3);
+    background: var(--bg-inset);
+  }
+
+  .shortcut-list dt {
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .shortcut-list dd {
+    margin: 0;
+  }
+
+  .tag-bindings {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-3);
+  }
+
+  .tag-binding {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .tag-binding :global(.kit-select-dropdown) {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .boundary,
+  .unavailable {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    line-height: 1.5;
+  }
+
+  .unavailable {
+    padding: var(--space-3);
+    border: 1px solid color-mix(in srgb, var(--accent-amber) 32%, transparent);
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--accent-amber) 8%, transparent);
+    color: var(--text-secondary);
+  }
+
+  @media (max-width: 640px) {
+    .shortcut-list,
+    .tag-bindings {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/ShortcutHelpModal.test.ts
+++ b/frontend/src/ShortcutHelpModal.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/svelte";
+import ShortcutHelpModal from "./ShortcutHelpModal.svelte";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  Object.defineProperty(Element.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(Element.prototype, "scrollIntoView");
+  vi.restoreAllMocks();
+});
+
+const tax = {
+  id: "33333333-3333-4333-8333-333333333333",
+  name: "tax",
+  revision: 2,
+  assignment_count: 4,
+};
+const missing = "44444444-4444-4444-8444-444444444444";
+
+it("makes browsing shortcuts discoverable and edits bounded tag bindings", async () => {
+  const onbindingchange = vi.fn();
+  render(ShortcutHelpModal, {
+    vaultReady: true,
+    catalog: [tax],
+    catalogTotal: 2,
+    bindings: { "1": tax.id, "2": missing },
+    onbindingchange,
+    onclose: vi.fn(),
+  });
+
+  expect(screen.getByRole("dialog", { name: "Keyboard shortcuts" })).toBeTruthy();
+  expect(screen.getByText("Focus search")).toBeTruthy();
+  expect(screen.getByText("Next loaded row")).toBeTruthy();
+  expect(screen.getByText("Toggle inspected file selection")).toBeTruthy();
+  expect(
+    screen.getByText(/Showing the first 1 of 2 tag definitions\./),
+  ).toBeTruthy();
+  expect(
+    screen.getByRole("combobox", { name: `Tag shortcut 2: Not in loaded catalog · ${missing}` }),
+  ).toBeTruthy();
+
+  const slotOne = screen.getByRole("combobox", { name: "Tag shortcut 1: tax" });
+  await fireEvent.click(slotOne);
+  await fireEvent.click(screen.getByRole("option", { name: "Unassigned" }));
+  expect(onbindingchange).toHaveBeenCalledWith("1", "");
+
+  const slotThree = screen.getByRole("combobox", {
+    name: "Tag shortcut 3: Unassigned",
+  });
+  await fireEvent.click(slotThree);
+  await fireEvent.click(screen.getByRole("option", { name: "tax" }));
+  expect(onbindingchange).toHaveBeenCalledWith("3", tax.id);
+});
+
+it("explains why tag bindings are disabled without a trustworthy vault ID", () => {
+  render(ShortcutHelpModal, {
+    vaultReady: false,
+    catalog: [tax],
+    catalogTotal: 1,
+    bindings: {},
+    onbindingchange: vi.fn(),
+    onclose: vi.fn(),
+  });
+
+  expect(
+    screen.getByText(
+      "Tag shortcuts are unavailable until this browser session confirms the vault identity.",
+    ),
+  ).toBeTruthy();
+  expect(
+    screen
+      .getByRole("combobox", { name: "Tag shortcut 1: Unassigned" })
+      .hasAttribute("disabled"),
+  ).toBe(true);
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -632,10 +632,12 @@ export async function restoreNode(
 
 export async function auditStatusForNode(
   session: string,
-  nodeID: number,
+  nodeID?: number,
 ): Promise<AuditStatus> {
   return requestJSON<AuditStatus>(
-    `/api/v1/audit/status?node_id=${encodeURIComponent(nodeID)}`,
+    nodeID === undefined
+      ? "/api/v1/audit/status"
+      : `/api/v1/audit/status?node_id=${encodeURIComponent(nodeID)}`,
     session,
   );
 }

--- a/frontend/src/shortcuts.test.ts
+++ b/frontend/src/shortcuts.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  isAppShortcutSuppressed,
+  moveInspection,
+} from "./shortcuts.js";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function keydown(target: Element, init: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "j",
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("application shortcut suppression", () => {
+  it.each([
+    ["input", "<input>"],
+    ["textarea descendant", "<textarea><span></span></textarea>"],
+    ["select", "<select></select>"],
+    ["contenteditable descendant", '<div contenteditable="true"><span></span></div>'],
+    ["button", "<button></button>"],
+    ["link descendant", '<a href="/elsewhere"><span></span></a>'],
+    ["checkbox role", '<div role="checkbox"><span></span></div>'],
+    ["menu item", '<div role="menuitem"><span></span></div>'],
+    ["combobox", '<div role="combobox"><span></span></div>'],
+  ])("preserves native keyboard behavior for %s", (_name, markup) => {
+    document.body.innerHTML = markup;
+    const target = document.querySelector("span") ?? document.body.firstElementChild!;
+    const event = keydown(target);
+
+    expect(isAppShortcutSuppressed(event, false)).toBe(true);
+  });
+
+  it("suppresses prevented, composing, unavailable, and modal interactions", () => {
+    const plain = document.body.appendChild(document.createElement("div"));
+
+    const prevented = new KeyboardEvent("keydown", { key: "j", cancelable: true });
+    prevented.preventDefault();
+    expect(isAppShortcutSuppressed(prevented, false)).toBe(true);
+    expect(
+      isAppShortcutSuppressed(
+        new KeyboardEvent("keydown", { key: "j", isComposing: true }),
+        false,
+      ),
+    ).toBe(true);
+    expect(isAppShortcutSuppressed(keydown(plain), true)).toBe(true);
+
+    const dialog = document.body.appendChild(document.createElement("div"));
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    expect(isAppShortcutSuppressed(keydown(plain), false)).toBe(true);
+  });
+
+  it("allows an unmodified shortcut from a noninteractive surface", () => {
+    const surface = document.body.appendChild(document.createElement("div"));
+    expect(isAppShortcutSuppressed(keydown(surface), false)).toBe(false);
+  });
+});
+
+describe("loaded-page inspection", () => {
+  const displayed = [{ id: 30 }, { id: 10 }, { id: 20 }];
+
+  it("moves in displayed order without sorting IDs", () => {
+    expect(moveInspection(displayed, 30, 1)).toEqual({ id: 10 });
+    expect(moveInspection(displayed, 20, -1)).toEqual({ id: 10 });
+  });
+
+  it("stops and reports the first and last loaded boundaries", () => {
+    expect(moveInspection(displayed, 30, -1)).toEqual({
+      id: 30,
+      boundary: "first",
+    });
+    expect(moveInspection(displayed, 20, 1)).toEqual({
+      id: 20,
+      boundary: "last",
+    });
+  });
+
+  it("is safe for empty pages and missing inspection", () => {
+    expect(moveInspection([], undefined, 1)).toEqual({ boundary: "empty" });
+    expect(moveInspection(displayed, undefined, 1)).toEqual({ id: 30 });
+    expect(moveInspection(displayed, 999, -1)).toEqual({ id: 20 });
+  });
+});

--- a/frontend/src/shortcuts.ts
+++ b/frontend/src/shortcuts.ts
@@ -1,0 +1,64 @@
+const NATIVE_KEYBOARD_ROLES = [
+  "button",
+  "link",
+  "checkbox",
+  "radio",
+  "switch",
+  "menu",
+  "menuitem",
+  "combobox",
+  "listbox",
+  "option",
+  "slider",
+  "spinbutton",
+  "tab",
+];
+
+const NATIVE_KEYBOARD_TARGETS = [
+  "input",
+  "textarea",
+  "select",
+  "button",
+  "a[href]",
+  "summary",
+  '[contenteditable]:not([contenteditable="false"])',
+  ...NATIVE_KEYBOARD_ROLES.map((role) => `[role=${role}]`),
+].join(",");
+
+const OPEN_DIALOGS = "[role=dialog][aria-modal=true], dialog[open]";
+
+export function isAppShortcutSuppressed(
+  event: KeyboardEvent,
+  unavailable: boolean,
+  root: ParentNode = document,
+): boolean {
+  if (event.defaultPrevented || event.isComposing || unavailable) return true;
+  if (root.querySelector(OPEN_DIALOGS)) return true;
+  const target = event.target;
+  return target instanceof Element && target.closest(NATIVE_KEYBOARD_TARGETS) !== null;
+}
+
+export type InspectionBoundary = "first" | "last" | "empty";
+
+export interface InspectionMove {
+  id?: number;
+  boundary?: InspectionBoundary;
+}
+
+export function moveInspection<T extends { id: number }>(
+  displayed: readonly T[],
+  inspectedID: number | undefined,
+  direction: -1 | 1,
+): InspectionMove {
+  if (displayed.length === 0) return { boundary: "empty" };
+  const current = displayed.findIndex((item) => item.id === inspectedID);
+  if (current < 0) {
+    return { id: direction > 0 ? displayed[0]!.id : displayed.at(-1)!.id };
+  }
+  const next = current + direction;
+  if (next < 0) return { id: displayed[0]!.id, boundary: "first" };
+  if (next >= displayed.length) {
+    return { id: displayed.at(-1)!.id, boundary: "last" };
+  }
+  return { id: displayed[next]!.id };
+}

--- a/frontend/src/tag-hotkeys.test.ts
+++ b/frontend/src/tag-hotkeys.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  loadTagHotkeys,
+  isTagHotkeyVaultID,
+  saveTagHotkeys,
+  tagHotkeyStorageKey,
+} from "./tag-hotkeys.js";
+
+const vaultA = "11111111-1111-4111-8111-111111111111";
+const vaultB = "22222222-2222-4222-8222-222222222222";
+const tax = "33333333-3333-4333-8333-333333333333";
+const reviewed = "44444444-4444-4444-8444-444444444444";
+
+function memoryStorage() {
+  const entries = new Map<string, string>();
+  return {
+    entries,
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => entries.set(key, value),
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("tag hotkey preferences", () => {
+  it("persists only versioned digit-to-tag IDs in a vault UUID namespace", () => {
+    const storage = memoryStorage();
+    expect(saveTagHotkeys(storage, vaultA, { "1": tax, "9": reviewed })).toBe(
+      true,
+    );
+
+    expect(tagHotkeyStorageKey(vaultA)).toBe(`docbank:tag-hotkeys:v1:${vaultA}`);
+    expect(storage.getItem(tagHotkeyStorageKey(vaultA))).toBe(
+      JSON.stringify({ version: 1, bindings: { "1": tax, "9": reviewed } }),
+    );
+    expect(loadTagHotkeys(storage, vaultA)).toEqual({
+      "1": tax,
+      "9": reviewed,
+    });
+  });
+
+  it("isolates preferences for two vaults", () => {
+    const storage = memoryStorage();
+    saveTagHotkeys(storage, vaultA, { "1": tax });
+    saveTagHotkeys(storage, vaultB, { "1": reviewed });
+
+    expect(loadTagHotkeys(storage, vaultA)).toEqual({ "1": tax });
+    expect(loadTagHotkeys(storage, vaultB)).toEqual({ "1": reviewed });
+  });
+
+  it.each([
+    ["malformed JSON", "{"],
+    ["wrong version", JSON.stringify({ version: 2, bindings: { "1": tax } })],
+    ["array payload", JSON.stringify({ version: 1, bindings: [] })],
+    ["bad key", JSON.stringify({ version: 1, bindings: { "0": tax } })],
+    ["bad tag ID", JSON.stringify({ version: 1, bindings: { "1": "tax" } })],
+  ])("rejects %s", (_name, payload) => {
+    const storage = memoryStorage();
+    storage.setItem(tagHotkeyStorageKey(vaultA), payload);
+    expect(loadTagHotkeys(storage, vaultA)).toEqual({});
+  });
+
+  it("tolerates blocked storage reads and writes", () => {
+    const blocked = {
+      getItem: vi.fn(() => {
+        throw new DOMException("blocked", "SecurityError");
+      }),
+      setItem: vi.fn(() => {
+        throw new DOMException("blocked", "SecurityError");
+      }),
+    };
+
+    expect(loadTagHotkeys(blocked, vaultA)).toEqual({});
+    expect(saveTagHotkeys(blocked, vaultA, { "1": tax })).toBe(false);
+  });
+
+  it("rejects untrusted vault namespaces and invalid values before storage", () => {
+    const storage = memoryStorage();
+    expect(isTagHotkeyVaultID(vaultA)).toBe(true);
+    expect(isTagHotkeyVaultID("short-lived-session")).toBe(false);
+    expect(loadTagHotkeys(storage, "short-lived-session")).toEqual({});
+    expect(saveTagHotkeys(storage, "short-lived-session", { "1": tax })).toBe(
+      false,
+    );
+    expect(saveTagHotkeys(storage, vaultA, { "1": "tax" })).toBe(false);
+    expect(storage.entries.size).toBe(0);
+  });
+});

--- a/frontend/src/tag-hotkeys.ts
+++ b/frontend/src/tag-hotkeys.ts
@@ -1,0 +1,71 @@
+export const TAG_HOTKEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"] as const;
+
+export type TagHotkey = (typeof TAG_HOTKEYS)[number];
+export type TagHotkeyBindings = Partial<Record<TagHotkey, string>>;
+
+type PreferenceStorage = Pick<Storage, "getItem" | "setItem">;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isTagHotkeyVaultID(value: unknown): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+function normalizeBindings(value: unknown): TagHotkeyBindings | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const allowed = new Set<string>(TAG_HOTKEYS);
+  if (Object.keys(record).some((key) => !allowed.has(key))) return undefined;
+  const normalized: TagHotkeyBindings = {};
+  for (const key of TAG_HOTKEYS) {
+    const tagID = record[key];
+    if (tagID === undefined) continue;
+    if (!isTagHotkeyVaultID(tagID)) return undefined;
+    normalized[key] = tagID;
+  }
+  return normalized;
+}
+
+export function tagHotkeyStorageKey(vaultID: string): string {
+  return `docbank:tag-hotkeys:v1:${vaultID}`;
+}
+
+export function loadTagHotkeys(
+  storage: Pick<PreferenceStorage, "getItem">,
+  vaultID: string,
+): TagHotkeyBindings {
+  if (!isTagHotkeyVaultID(vaultID)) return {};
+  try {
+    const raw = storage.getItem(tagHotkeyStorageKey(vaultID));
+    if (raw === null) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const envelope = parsed as Record<string, unknown>;
+    if (envelope.version !== 1 || Object.keys(envelope).some((key) => key !== "version" && key !== "bindings")) {
+      return {};
+    }
+    return normalizeBindings(envelope.bindings) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveTagHotkeys(
+  storage: Pick<PreferenceStorage, "setItem">,
+  vaultID: string,
+  bindings: TagHotkeyBindings,
+): boolean {
+  if (!isTagHotkeyVaultID(vaultID)) return false;
+  const normalized = normalizeBindings(bindings);
+  if (!normalized) return false;
+  try {
+    storage.setItem(
+      tagHotkeyStorageKey(vaultID),
+      JSON.stringify({ version: 1, bindings: normalized }),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Browse the loaded document list and toggle tags without moving between the mouse and keyboard.

Press `?` for shortcut help. `/` focuses search, `j` and `k` move between loaded rows, Space toggles file selection, Enter opens the inspected folder, and Escape clears selection. Assign digits `1`–`9` to tags in the help dialog; bindings stay separate for each vault and must be set again after the daemon restarts or browser data is cleared.

Navigation stops at the loaded-page boundary. Tag shortcuts affect only the inspected file, regardless of checked rows, and use its displayed revision. A conflict requires a refresh; it never silently retries against newer state. Shortcuts pause during text entry and dialogs.

![Keyboard shortcut help with a synthetic document and tag binding](https://raw.githubusercontent.com/salmonumbrella/docbank/0f57c4d26efd94c27f253f6684b60637d27626fb/web-keyboard-shortcuts.png)
