### PR TITLE
Apply tags atomically to selected documents

### DIFF
--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -305,9 +305,11 @@ normalization and validation and returns `422` for an invalid path.
 The body is limited to 1 MiB and 1–1,000 unique live file or directory IDs with
 positive exact revisions. No query, subtree expansion, or `If-Match` header is
 used. Invalid structure returns 422, missing or trashed targets return 404,
-and a stale target returns 409. Every target, including assignment no-ops,
+and a stale target returns 412 (`stale_revision`). Every target, including assignment no-ops,
 is validated in the same transaction as all changes and receipt persistence.
-Actual changes use the existing canonical audit events.
+Actual changes use the existing canonical audit events, with a separate audit
+operation for each changed node. The receipt's operation ID identifies the
+batch retry; it is not an audit operation ID.
 
 Success returns 200 with `version: 1`, `operation_id`, `request_digest`,
 `tag_id`, `assign`, final `tag_revision`, final `assignment_count`,

--- a/docs/architecture/http-api.md
+++ b/docs/architecture/http-api.md
@@ -60,6 +60,7 @@ Endpoints are filesystem-shaped, under `/api/v1`:
 | `PATCH /nodes/{id}` | move and/or rename, including resolving an absolute `dest_path` transactionally | Implemented |
 | `POST /path/move` · `POST /path/trash` | move / trash by virtual path, resolved and mutated in one store transaction | Implemented |
 | `POST /batch/move` | validate and apply up to 1,000 moves as one final-state transaction | Implemented |
+| `POST /batch/tags` · `POST /batch/tags/preview` | atomically assign/remove one tag on a revision-fenced selected set, or inspect its exact membership | Implemented |
 | `POST /nodes/{id}/trash` · `POST /nodes/{id}/restore` | soft delete / recover | Implemented |
 | `GET /trash` · `POST /trash/empty` `{run, older_than}` | list (optionally paginated) / report or hard-delete trash roots | Implemented |
 | `POST /gc` `{run}` · `POST /verify` | reclaim unreachable blobs / validate metadata and re-hash all blobs | Implemented |
@@ -296,6 +297,48 @@ wildcard segment makes a route ambiguous for names containing
 encoding instead. The path must be absolute (leading `/`); `?path=/`
 resolves the root. The server applies the store's existing NFC name
 normalization and validation and returns `422` for an invalid path.
+
+## Batch tag assignment
+
+`POST /api/v1/batch/tags` accepts a canonical UUIDv4 `operation_id`, a tag UUID
+`tag_id`, required boolean `assign`, and `nodes: [{node_id, revision}]`.
+The body is limited to 1 MiB and 1–1,000 unique live file or directory IDs with
+positive exact revisions. No query, subtree expansion, or `If-Match` header is
+used. Invalid structure returns 422, missing or trashed targets return 404,
+and a stale target returns 409. Every target, including assignment no-ops,
+is validated in the same transaction as all changes and receipt persistence.
+Actual changes use the existing canonical audit events.
+
+Success returns 200 with `version: 1`, `operation_id`, `request_digest`,
+`tag_id`, `assign`, final `tag_revision`, final `assignment_count`,
+`completed_at`, and numerically sorted
+`nodes: [{node_id, expected_revision, revision, changed}]`. Every requested
+identity appears exactly once. Changed nodes advance by one revision;
+unchanged nodes retain their expected revision.
+
+Request order is not semantic. The lowercase SHA-256 request digest covers
+UTF-8 text: `docbank-tag-batch-v1` followed by newline, the canonical tag UUID
+followed by newline, `1` for assignment or `0` for removal followed by newline,
+then one `node_id:revision` line per target in ascending numeric node-ID order.
+Every line, including the last, ends in newline; integers use unpadded decimal.
+The operation UUID is a separate lookup identity, not part of that digest.
+
+Repeating an operation with the same canonical request returns its original
+receipt, even after later edits or deletion. Reusing the operation UUID with
+different input returns 409 `batch_tag_operation_conflict`. Receipts are
+retained indefinitely without node/tag cascade deletion and contain no names,
+paths, or document bodies. Metadata and physical backup/restore retain receipts
+present at the backup checkpoint; an earlier backup cannot know later
+operations. A historical success does not assert current membership or
+recreate a deleted entity. Clients must validate complete receipt identity and
+revision outcomes before accepting success.
+
+`POST /api/v1/batch/tags/preview` takes only `tag_id` and the same bounded,
+revision-fenced `nodes`. One read snapshot returns `tag_id`, `tag_revision`,
+and sorted `nodes: [{node_id, revision, assigned}]`, with no durable changes.
+This provides exact selected-set membership without interpreting omissions
+from a truncated tag listing. Both routes require authentication. Browser
+sessions permit only these exact POST paths without query arguments.
 
 ## Concurrency: resource revisions and `If-Match`
 

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -124,7 +124,7 @@ those assignments are removed.
 
 ## Tag a selected set atomically
 
-In the web app, select document checkboxes and choose **Add tags**. Pick one
+In the web app, select document checkboxes and choose **Edit tags**. Pick one
 tag to see how many selected documents have it, then choose **Add to all** or
 **Remove from all**. Each operation accepts at most 1,000 explicit documents.
 If any target is missing, trashed, or has changed since selection, the whole

--- a/docs/usage/organizing.md
+++ b/docs/usage/organizing.md
@@ -1,4 +1,5 @@
 ---
+last_edited: 2026-09-11
 title: Organizing & Tagging
 description: Browsing, moving, renaming, and tagging in the virtual tree.
 ---
@@ -120,6 +121,28 @@ retain their tag assignments and appear as `trashed` in `tag nodes`; path-based
 assignment commands intentionally address live nodes only. When `trash empty`
 permanently deletes tagged nodes, each affected tag revision advances before
 those assignments are removed.
+
+## Tag a selected set atomically
+
+In the web app, select document checkboxes and choose **Add tags**. Pick one
+tag to see how many selected documents have it, then choose **Add to all** or
+**Remove from all**. Each operation accepts at most 1,000 explicit documents.
+If any target is missing, trashed, or has changed since selection, the whole
+operation fails without changing assignments. Already-correct assignments
+keep their node revisions; actual changes retain the normal audit events.
+
+If the response is lost, keep the dialog open and choose **Retry same
+operation**. The daemon returns the original receipt without applying the
+change twice. A conflict requires closing the dialog and explicitly refreshing
+the selection. Closing an uncertain operation discards the browser's retry
+request, not any change already committed by the daemon.
+
+API clients use `POST /api/v1/batch/tags` with one tag ID, an operation UUID,
+an assignment choice, and exact node/revision pairs. Receipts are retained
+indefinitely, including after tag or node deletion, and survive backup/restore
+when included in that backup checkpoint. They contain identities and revisions,
+not filenames or tag names. A replay confirms the original outcome, not current
+membership. See the [batch tag contract](../architecture/http-api.md#batch-tag-assignment).
 
 ## Atomic bulk reorganization
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -1,5 +1,5 @@
 ---
-last_edited: 2026-09-10
+last_edited: 2026-09-11
 title: Web application
 description: Upload, browse, search, and organize the local vault in a responsive, authenticated web interface.
 ---
@@ -103,6 +103,22 @@ status. If another person, agent, or CLI command changed the node first, the
 dialog keeps the failed decision visible and asks you to refresh rather than
 applying it to newer state.
 
+### Tag selected documents
+
+Use the document checkboxes to select files on the displayed page, then choose
+**Add tags** in the selection dock. The picker shows whether all, some, or none
+of the selected documents have the chosen tag. **Add to all** and **Remove from
+all** apply one atomic, revision-fenced operation to at most 1,000 documents.
+Folders and undisplayed query results are not included in page selection.
+
+Keep the dialog open if the result is uncertain: **Retry same operation**
+reuses its original identity and revisions. A stale selection requires an
+explicit refresh rather than an automatic retry against newer documents.
+After confirmation, the browser reloads current observations; the retained
+receipt may describe an earlier successful operation. See
+[selected-set tagging](organizing.md#tag-a-selected-set-atomically) for retention
+and backup behavior.
+
 ## Manage tag definitions
 
 Choose the tag-catalog button beside the toolbar selector to create, rename,
@@ -126,7 +142,7 @@ change assignment rules.
 
 The catalog shows the first 1,000 name-sorted definitions and discloses the
 complete count. Use `docbank tag`, the paginated HTTP API, or an embedded client
-for exhaustive definition management and bulk assignment.
+for exhaustive definition management and assignments outside the displayed selection.
 
 ## Saved queries and highlights
 

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -106,7 +106,7 @@ applying it to newer state.
 ### Tag selected documents
 
 Use the document checkboxes to select files on the displayed page, then choose
-**Add tags** in the selection dock. The picker shows whether all, some, or none
+**Edit tags** in the selection dock. The picker shows whether all, some, or none
 of the selected documents have the chosen tag. **Add to all** and **Remove from
 all** apply one atomic, revision-fenced operation to at most 1,000 documents.
 Folders and undisplayed query results are not included in page selection.

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -27,7 +27,6 @@ const tuiStorageScreenshotPath = screenshotPathFor("tui-multi-store-storage.png"
 const vaultBrowserScreenshotPath = screenshotPathFor("web-vault-browser.png");
 const pageSelectionScreenshotPath = screenshotPathFor("web-page-selection.png");
 const pageSelectionMobileScreenshotPath = screenshotPathFor("web-page-selection-mobile.png");
-const batchTagsScreenshotPath = screenshotPathFor("web-batch-tags.png");
 const searchResultsScreenshotPath = screenshotPathFor("web-search-results.png");
 const retainedVersionScreenshotPath = screenshotPathFor(
   "web-retained-version-download.png",
@@ -139,7 +138,6 @@ test.describe("Docbank web screenshots", () => {
     await rm(vaultBrowserScreenshotPath, { force: true });
     await rm(pageSelectionScreenshotPath, { force: true });
     await rm(pageSelectionMobileScreenshotPath, { force: true });
-    await rm(batchTagsScreenshotPath, { force: true });
     await rm(searchResultsScreenshotPath, { force: true });
     await rm(retainedVersionScreenshotPath, { force: true });
     await rm(packedStorageScreenshotPath, { force: true });
@@ -393,12 +391,11 @@ test.describe("Docbank web screenshots", () => {
       fullPage: false,
       animations: "disabled",
     });
-    await selectionDock.getByRole("button", { name: "Add tags" }).click();
+    await selectionDock.getByRole("button", { name: "Edit tags" }).click();
     const batchTags = page.getByRole("dialog", { name: "Tag selected documents" });
     await batchTags.getByRole("combobox", { name: "Tag for selected documents: Choose a tag…" }).click();
     await page.getByRole("option", { name: "tax", exact: true }).click();
     await expect(batchTags.getByText("1 of 2 selected documents have this tag.")).toBeVisible();
-    await page.screenshot({ path: batchTagsScreenshotPath, fullPage: false, animations: "disabled" });
     await batchTags.getByRole("button", { name: "Done" }).click();
     await selectionDock
       .getByRole("button", { name: "Clear selection" })

--- a/frontend/screenshots/web-trash.screenshot.ts
+++ b/frontend/screenshots/web-trash.screenshot.ts
@@ -27,6 +27,7 @@ const tuiStorageScreenshotPath = screenshotPathFor("tui-multi-store-storage.png"
 const vaultBrowserScreenshotPath = screenshotPathFor("web-vault-browser.png");
 const pageSelectionScreenshotPath = screenshotPathFor("web-page-selection.png");
 const pageSelectionMobileScreenshotPath = screenshotPathFor("web-page-selection-mobile.png");
+const batchTagsScreenshotPath = screenshotPathFor("web-batch-tags.png");
 const searchResultsScreenshotPath = screenshotPathFor("web-search-results.png");
 const retainedVersionScreenshotPath = screenshotPathFor(
   "web-retained-version-download.png",
@@ -138,6 +139,7 @@ test.describe("Docbank web screenshots", () => {
     await rm(vaultBrowserScreenshotPath, { force: true });
     await rm(pageSelectionScreenshotPath, { force: true });
     await rm(pageSelectionMobileScreenshotPath, { force: true });
+    await rm(batchTagsScreenshotPath, { force: true });
     await rm(searchResultsScreenshotPath, { force: true });
     await rm(retainedVersionScreenshotPath, { force: true });
     await rm(packedStorageScreenshotPath, { force: true });
@@ -152,7 +154,9 @@ test.describe("Docbank web screenshots", () => {
       { mode: 0o600 },
     );
     const reports = path.join(workspace, "synthetic", "Reports");
+    const longReports = path.join(workspace, "synthetic", "Long Reports");
     await mkdir(reports, { recursive: true, mode: 0o700 });
+    await mkdir(longReports, { recursive: true, mode: 0o700 });
     await writeFile(
       path.join(reports, "quarterly-tax-report.txt"),
       "Synthetic quarterly tax report for screenshot validation.\n",
@@ -168,6 +172,15 @@ test.describe("Docbank web screenshots", () => {
       "category,amount\nSynthetic revenue,125000\nSynthetic expense,42000\n",
       { mode: 0o600 },
     );
+    await Promise.all(
+      Array.from({ length: 100 }, (_, index) =>
+        writeFile(
+          path.join(longReports, `document-${String(index).padStart(3, "0")}.txt`),
+          `Extended listing fixture document ${index}.\n`,
+          { mode: 0o600 },
+        ),
+      ),
+    );
     const archiveReference = path.join(
       workspace,
       "synthetic",
@@ -180,6 +193,7 @@ test.describe("Docbank web screenshots", () => {
     );
 
     await runDocbank(["add", reports, "--dest", "/", "--progress", "plain"]);
+    await runDocbank(["add", longReports, "--dest", "/", "--progress", "plain"]);
     await runDocbank([
       "add",
       archiveReference,
@@ -379,6 +393,13 @@ test.describe("Docbank web screenshots", () => {
       fullPage: false,
       animations: "disabled",
     });
+    await selectionDock.getByRole("button", { name: "Add tags" }).click();
+    const batchTags = page.getByRole("dialog", { name: "Tag selected documents" });
+    await batchTags.getByRole("combobox", { name: "Tag for selected documents: Choose a tag…" }).click();
+    await page.getByRole("option", { name: "tax", exact: true }).click();
+    await expect(batchTags.getByText("1 of 2 selected documents have this tag.")).toBeVisible();
+    await page.screenshot({ path: batchTagsScreenshotPath, fullPage: false, animations: "disabled" });
+    await batchTags.getByRole("button", { name: "Done" }).click();
     await selectionDock
       .getByRole("button", { name: "Clear selection" })
       .click();

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -41,9 +41,10 @@
   import JobsDrawer from "./JobsDrawer.svelte";
   import ManageTagsModal from "./ManageTagsModal.svelte";
   import BatchTagsModal from "./BatchTagsModal.svelte";
-  import type { BatchTagReceipt, BatchTagTarget } from "./batch-tags.js";
+  import type { BatchTagReceipt } from "./batch-tags.js";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import SelectionDock from "./SelectionDock.svelte";
+  import type { SelectionTarget } from "./selection.js";
   import StorageDrawer from "./StorageDrawer.svelte";
   import SavedQueriesDrawer from "./SavedQueriesDrawer.svelte";
   import { parseQuery, type Query } from "./query.js";
@@ -151,7 +152,7 @@
   let queryURLError = $state("");
   let trashOpen = $state(false);
   let manageTagsTarget = $state<Row | null>(null);
-  let batchTagsTargets = $state<BatchTagTarget[] | null>(null);
+  let batchTagsTargets = $state<SelectionTarget[] | null>(null);
   let tagCatalogOpen = $state(false);
   let uploadTarget = $state<Node | null>(null);
   let trashTarget = $state<Row | null>(null);
@@ -644,8 +645,8 @@
     else void loadRoot();
   }
 
-  function openBatchTags(targets: readonly BatchTagTarget[]): void {
-    if (loading || targets.length === 0 || targets.length > 1000) return;
+  function openBatchTags(targets: readonly SelectionTarget[]): void {
+    if (loading) return;
     batchTagsTargets = targets.map((target) => ({ ...target }));
   }
 
@@ -1554,6 +1555,7 @@
         onclear={clearBulkSelection}
         onselectvisible={() => selectAllVisibleDocuments()}
         ontags={() => openBatchTags(bulkTargets)}
+        tagsDisabled={loading}
       />
     {/if}
     {#if historyOpen && selected && membership?.protected}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -40,6 +40,8 @@
   import DownloadButton from "./DownloadButton.svelte";
   import JobsDrawer from "./JobsDrawer.svelte";
   import ManageTagsModal from "./ManageTagsModal.svelte";
+  import BatchTagsModal from "./BatchTagsModal.svelte";
+  import type { BatchTagReceipt, BatchTagTarget } from "./batch-tags.js";
   import ProvenanceDrawer from "./ProvenanceDrawer.svelte";
   import SelectionDock from "./SelectionDock.svelte";
   import StorageDrawer from "./StorageDrawer.svelte";
@@ -80,6 +82,7 @@
     clearSelection,
     reconcileSelection,
     selectVisibleDocuments,
+    selectedTargets,
     toggleDocumentSelection,
     type SelectionState,
   } from "./selection.js";
@@ -148,6 +151,7 @@
   let queryURLError = $state("");
   let trashOpen = $state(false);
   let manageTagsTarget = $state<Row | null>(null);
+  let batchTagsTargets = $state<BatchTagTarget[] | null>(null);
   let tagCatalogOpen = $state(false);
   let uploadTarget = $state<Node | null>(null);
   let trashTarget = $state<Row | null>(null);
@@ -175,6 +179,7 @@
     sortedRows.filter((row) => row.node.kind === "file").length,
   );
   const selectedCount = $derived(bulkSelection.selectedIDs.size);
+  const bulkTargets = $derived(selectedTargets(sortedRows, bulkSelection.selectedIDs));
   const allVisibleDocumentsSelected = $derived(
     visibleDocumentCount > 0 && selectedCount === visibleDocumentCount,
   );
@@ -639,6 +644,18 @@
     else void loadRoot();
   }
 
+  function openBatchTags(targets: readonly BatchTagTarget[]): void {
+    if (loading || targets.length === 0 || targets.length > 1000) return;
+    batchTagsTargets = targets.map((target) => ({ ...target }));
+  }
+
+  function handleBatchTagsChanged(_receipt: BatchTagReceipt): void {
+    // A replay describes a historical success. Reload current observations
+    // instead of overwriting newer rows with the receipt's old revisions.
+    refreshCurrentView();
+    if (selectedID !== undefined) void loadSelectedTags(selectedID);
+  }
+
   function handleTrashed(_receipt: Node): void {
     trashTarget = null;
     selectNode(undefined);
@@ -862,6 +879,7 @@
     backupsOpen = false;
     trashOpen = false;
     manageTagsTarget = null;
+    batchTagsTargets = null;
     tagCatalogOpen = false;
     uploadTarget = null;
     trashTarget = null;
@@ -1535,6 +1553,7 @@
         {truncated}
         onclear={clearBulkSelection}
         onselectvisible={() => selectAllVisibleDocuments()}
+        ontags={() => openBatchTags(bulkTargets)}
       />
     {/if}
     {#if historyOpen && selected && membership?.protected}
@@ -1620,6 +1639,18 @@
         disabled={loading}
         onclose={() => (manageTagsTarget = null)}
         onchanged={handleTagChanged}
+        onauthfailure={handleFailure}
+      />
+    {/if}
+    {#if batchTagsTargets}
+      <BatchTagsModal
+        session={webSession}
+        targets={batchTagsTargets}
+        catalog={tagCatalog}
+        catalogTotal={tagCatalogTotal}
+        disabled={loading}
+        onclose={() => (batchTagsTargets = null)}
+        onchanged={handleBatchTagsChanged}
         onauthfailure={handleFailure}
       />
     {/if}

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1045,7 +1045,7 @@ it("opens bounded tag assignment for the exact page selection", async () => {
   installSelectionBackend();
   render(App);
   await fireEvent.click(await screen.findByRole("checkbox", { name: "Select readme.txt" }));
-  await fireEvent.click(screen.getByRole("button", { name: "Add tags" }));
+  await fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
   const dialog = await screen.findByRole("dialog", { name: "Tag selected documents" });
   expect(within(dialog).getByText(/1 selected document\./)).toBeTruthy();
   expect((within(dialog).getByRole("button", { name: "Add to all" }) as HTMLButtonElement).disabled).toBe(true);

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1040,6 +1040,19 @@ function prepareSelectionApp(): void {
   });
 }
 
+it("opens bounded tag assignment for the exact page selection", async () => {
+  prepareSelectionApp();
+  installSelectionBackend();
+  render(App);
+  await fireEvent.click(await screen.findByRole("checkbox", { name: "Select readme.txt" }));
+  await fireEvent.click(screen.getByRole("button", { name: "Add tags" }));
+  const dialog = await screen.findByRole("dialog", { name: "Tag selected documents" });
+  expect(within(dialog).getByText(/1 selected document\./)).toBeTruthy();
+  expect((within(dialog).getByRole("button", { name: "Add to all" }) as HTMLButtonElement).disabled).toBe(true);
+  await fireEvent.click(within(dialog).getByRole("button", { name: "Done" }));
+  expect(screen.queryByRole("dialog", { name: "Tag selected documents" })).toBeNull();
+});
+
 it("selects displayed files without requests or changing the inspector, then reconciles a refresh", async () => {
   prepareSelectionApp();
   const { fetchMock, getReportsReads } = installSelectionBackend();

--- a/frontend/src/BatchTagsModal.svelte
+++ b/frontend/src/BatchTagsModal.svelte
@@ -2,11 +2,12 @@
   import { onDestroy, untrack } from "svelte";
   import { Button, Checkbox, Modal, SelectDropdown, Spinner, type SelectDropdownOption } from "@kenn-io/kit-ui";
   import { APIError, type Tag } from "./api.js";
-  import { changeBatchTags, previewBatchTags, type BatchTagTarget, type BatchTagRequest, type BatchTagReceipt, type BatchTagPreview } from "./batch-tags.js";
+  import type { SelectionTarget } from "./selection.js";
+  import { changeBatchTags, previewBatchTags, type BatchTagRequest, type BatchTagReceipt, type BatchTagPreview } from "./batch-tags.js";
 
   interface Props {
     session: string;
-    targets: readonly BatchTagTarget[];
+    targets: readonly SelectionTarget[];
     catalog: Tag[];
     catalogTotal: number;
     disabled: boolean;
@@ -55,7 +56,7 @@
     } catch (cause) {
       if (!alive || requestGeneration !== generation) return;
       if (cause instanceof APIError && cause.status === 401) { onauthfailure(cause); return; }
-      stale = cause instanceof APIError && cause.status === 409;
+      stale = cause instanceof APIError && (cause.code === "stale_revision" || cause.code === "not_found");
       failure = cause instanceof Error ? cause.message : String(cause);
     } finally {
       if (alive && requestGeneration === generation) loading = false;
@@ -85,7 +86,7 @@
       if (!alive) return;
       if (cause instanceof APIError && cause.status >= 400 && cause.status < 500) {
         uncertain = undefined;
-        stale = cause.status === 409;
+        stale = cause.code === "stale_revision" || cause.code === "not_found";
         if (cause.status === 401) { onauthfailure(cause); return; }
       } else {
         uncertain = request;

--- a/frontend/src/BatchTagsModal.svelte
+++ b/frontend/src/BatchTagsModal.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { onDestroy, untrack } from "svelte";
+  import { Button, Checkbox, Modal, SelectDropdown, Spinner, type SelectDropdownOption } from "@kenn-io/kit-ui";
+  import { APIError, type Tag } from "./api.js";
+  import { changeBatchTags, previewBatchTags, type BatchTagTarget, type BatchTagRequest, type BatchTagReceipt, type BatchTagPreview } from "./batch-tags.js";
+
+  interface Props {
+    session: string;
+    targets: readonly BatchTagTarget[];
+    catalog: Tag[];
+    catalogTotal: number;
+    disabled: boolean;
+    onclose: () => void;
+    onchanged: (receipt: BatchTagReceipt) => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+  let { session, targets, catalog, catalogTotal, disabled, onclose, onchanged, onauthfailure }: Props = $props();
+  let currentTargets = $state(untrack(() => targets.map((target) => ({ ...target }))));
+  let tagID = $state("");
+  let preview = $state<BatchTagPreview>();
+  let uncertain = $state<BatchTagRequest>();
+  let loading = $state(false);
+  let pending = $state(false);
+  let stale = $state(false);
+  let closingUncertain = $state(false);
+  let failure = $state("");
+  let notice = $state("");
+  let generation = 0;
+  let alive = true;
+  onDestroy(() => { alive = false; generation++; });
+
+  const options = $derived<SelectDropdownOption[]>([
+    { value: "", label: "Choose a tag…" },
+    ...catalog.map((tag) => ({ value: tag.id, label: tag.name })),
+  ]);
+  const assignedCount = $derived(preview?.nodes.filter((node) => node.assigned).length ?? 0);
+  const busy = $derived(disabled || pending || loading);
+  const canChange = $derived(!busy && !stale && !uncertain && preview !== undefined);
+
+  function close() {
+    if (pending || loading) return;
+    if (uncertain) { closingUncertain = true; return; }
+    onclose();
+  }
+
+  async function loadPreview() {
+    const requestGeneration = ++generation;
+    preview = undefined;
+    failure = "";
+    if (!tagID) return;
+    loading = true;
+    try {
+      const result = await previewBatchTags(session, tagID, currentTargets);
+      if (alive && requestGeneration === generation) preview = result;
+    } catch (cause) {
+      if (!alive || requestGeneration !== generation) return;
+      if (cause instanceof APIError && cause.status === 401) { onauthfailure(cause); return; }
+      stale = cause instanceof APIError && cause.status === 409;
+      failure = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (alive && requestGeneration === generation) loading = false;
+    }
+  }
+
+  function selectTag(value: string) {
+    if (busy || stale || uncertain) return;
+    tagID = value;
+    notice = "";
+    void loadPreview();
+  }
+
+  async function submit(request: BatchTagRequest) {
+    pending = true;
+    failure = "";
+    closingUncertain = false;
+    try {
+      const receipt = await changeBatchTags(session, request);
+      if (!alive) return;
+      uncertain = undefined;
+      currentTargets = receipt.nodes.map((node) => ({ node_id: node.node_id, revision: node.revision }));
+      notice = `Operation confirmed: ${receipt.nodes.filter((node) => node.changed).length} changed, ${receipt.nodes.filter((node) => !node.changed).length} already in the requested state.`;
+      onchanged(receipt);
+      await loadPreview();
+    } catch (cause) {
+      if (!alive) return;
+      if (cause instanceof APIError && cause.status >= 400 && cause.status < 500) {
+        uncertain = undefined;
+        stale = cause.status === 409;
+        if (cause.status === 401) { onauthfailure(cause); return; }
+      } else {
+        uncertain = request;
+      }
+      failure = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      if (alive) pending = false;
+    }
+  }
+
+  function change(assign: boolean) {
+    if (!canChange) return;
+    try {
+      const request = { operation_id: crypto.randomUUID(), tag_id: tagID, assign,
+        nodes: currentTargets.map((target) => ({ ...target })) };
+      void submit(request);
+    } catch (cause) {
+      failure = cause instanceof Error ? cause.message : String(cause);
+    }
+  }
+</script>
+
+<Modal title="Tag selected documents" tone="info" width="620px" maxWidth="min(620px, calc(100vw - 32px))"
+  ariaLabel="Tag selected documents" onclose={close} closeOnOverlayClick={!pending && !loading}>
+  <div class="batch-tags">
+    <p>{currentTargets.length} selected document{currentTargets.length === 1 ? "" : "s"}. Each operation changes one tag across this exact selection, or changes nothing if a document is stale.</p>
+    <SelectDropdown value={tagID} {options} title="Tag for selected documents"
+      disabled={busy || stale || uncertain !== undefined} onchange={selectTag} />
+    {#if catalogTotal > catalog.length}
+      <p class="hint">Showing {catalog.length} of {catalogTotal} tag definitions. Definitions outside this catalog page remain available through the API.</p>
+    {/if}
+    {#if loading}<div class="loading"><Spinner size={16} /> Checking selected documents…</div>{/if}
+    {#if preview}
+      <Checkbox checked={assignedCount === currentTargets.length}
+        indeterminate={assignedCount > 0 && assignedCount < currentTargets.length}
+        disabled ariaLabel="Selected tag membership" label={`${assignedCount} of ${currentTargets.length} selected documents have this tag.`} />
+    {/if}
+    <div class="actions">
+      <Button tone="info" disabled={!canChange || assignedCount === currentTargets.length} onclick={() => change(true)}>Add to all</Button>
+      <Button disabled={!canChange || assignedCount === 0} onclick={() => change(false)}>Remove from all</Button>
+    </div>
+    {#if pending}<div class="loading"><Spinner size={16} /> Confirming operation…</div>{/if}
+    {#if notice}<p role="status">{notice}</p>{/if}
+    {#if failure}<p role="alert">{failure}</p>{/if}
+    {#if stale}<p>Close and refresh your selection before starting another operation. Expected revisions have not been replaced automatically.</p>{/if}
+    {#if uncertain}
+      <p>The result is uncertain. Retry uses the same operation identity and original revisions; it cannot apply the change twice.</p>
+      <Button disabled={busy} onclick={() => uncertain && void submit(uncertain)}>Retry same operation</Button>
+    {/if}
+    {#if closingUncertain}
+      <p role="alert">Closing loses this browser’s retry request without confirming the result. Refresh the documents before starting new work.</p>
+      <Button disabled={busy} onclick={onclose}>Close without confirmation</Button>
+    {/if}
+    <p class="hint">No query-wide selection or automatic conflict retry. A confirmed receipt describes the original operation; current membership is checked again afterward.</p>
+  </div>
+  {#snippet footer()}<Button surface="soft" disabled={pending || loading} onclick={close}>Done</Button>{/snippet}
+</Modal>
+
+<style>
+  .batch-tags { display: grid; gap: var(--space-4); }
+  .batch-tags p { margin: 0; }
+  .actions, .loading { display: flex; align-items: center; gap: var(--space-3); flex-wrap: wrap; }
+  .hint { color: var(--text-muted); font-size: var(--text-sm); }
+</style>

--- a/frontend/src/BatchTagsModal.test.ts
+++ b/frontend/src/BatchTagsModal.test.ts
@@ -55,7 +55,7 @@ it("shows exact mixed membership and retries the same uncertain operation", asyn
 });
 
 it("requires explicit reselection after a stale preview", async () => {
-  vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ detail: "Selection is stale", code: "stale_revision" }), { status: 409 }));
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ detail: "Selection is stale", code: "stale_revision" }), { status: 412 }));
   const onclose = vi.fn();
   render(BatchTagsModal, { session: "session", targets, catalog: [tag], catalogTotal: 3,
     disabled: false, onclose, onchanged: vi.fn(), onauthfailure: vi.fn() });
@@ -64,4 +64,30 @@ it("requires explicit reselection after a stale preview", async () => {
   expect((screen.getByRole("button", { name: "Add to all" }) as HTMLButtonElement).disabled).toBe(true);
   await fireEvent.click(screen.getByRole("button", { name: "Done" }));
   expect(onclose).toHaveBeenCalledOnce();
+});
+
+it.each([
+  { status: 412, code: "stale_revision", refresh: true },
+  { status: 404, code: "not_found", refresh: true },
+  { status: 409, code: "audit_mutation_unsupported", refresh: false },
+  { status: 409, code: "batch_tag_operation_conflict", refresh: false },
+])("handles $code after a successful preview", async ({ status, code, refresh }) => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+    if (String(url).endsWith("/preview")) {
+      return new Response(JSON.stringify({ tag_id: tag.id, tag_revision: 2,
+        nodes: targets.map((target, index) => ({ ...target, assigned: index === 0 })),
+      }));
+    }
+    return new Response(JSON.stringify({ detail: code, code }), { status });
+  });
+  render(BatchTagsModal, { session: "session", targets, catalog: [tag], catalogTotal: 1,
+    disabled: false, onclose: vi.fn(), onchanged: vi.fn(), onauthfailure: vi.fn() });
+  await chooseTag();
+  await screen.findByText("1 of 2 selected documents have this tag.");
+  await fireEvent.click(screen.getByRole("button", { name: "Add to all" }));
+  expect((await screen.findByRole("alert")).textContent).toBe(code);
+  expect(screen.queryByText(/Close and refresh your selection/) !== null).toBe(refresh);
+  expect((screen.getByRole("button", { name: "Add to all" }) as HTMLButtonElement).disabled).toBe(refresh);
+  expect((screen.getByRole("button", { name: "Remove from all" }) as HTMLButtonElement).disabled).toBe(refresh);
+  expect(screen.queryByRole("button", { name: "Retry same operation" })).toBeNull();
 });

--- a/frontend/src/BatchTagsModal.test.ts
+++ b/frontend/src/BatchTagsModal.test.ts
@@ -1,0 +1,67 @@
+import { webcrypto } from "node:crypto";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import BatchTagsModal from "./BatchTagsModal.svelte";
+
+const tag = { id: "22222222-2222-4222-8222-222222222222", name: "Review", revision: 2, assignment_count: 1 };
+const targets = [{ node_id: 7, revision: 3 }, { node_id: 9, revision: 4 }];
+
+beforeEach(() => {
+  vi.stubGlobal("crypto", webcrypto);
+  vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} });
+  Object.defineProperty(Element.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
+});
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.restoreAllMocks(); Reflect.deleteProperty(Element.prototype, "scrollIntoView"); });
+
+async function chooseTag() {
+  await fireEvent.click(screen.getByRole("combobox", { name: "Tag for selected documents: Choose a tag…" }));
+  await fireEvent.click(screen.getByRole("option", { name: "Review" }));
+}
+
+it("shows exact mixed membership and retries the same uncertain operation", async () => {
+  const requests: { operation_id: string; nodes: typeof targets }[] = [];
+  const onchanged = vi.fn();
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+    if (String(url).endsWith("/preview")) {
+      const complete = requests.length === 2;
+      return new Response(JSON.stringify({ tag_id: tag.id, tag_revision: complete ? 3 : 2,
+        nodes: [{ node_id: 7, revision: 3, assigned: true }, { node_id: 9, revision: complete ? 5 : 4, assigned: complete }],
+      }), { status: 200 });
+    }
+    const request = JSON.parse(String(init?.body));
+    requests.push(request);
+    if (requests.length === 1) throw new TypeError("Synthetic response loss");
+    return new Response(JSON.stringify({ version: 1, operation_id: request.operation_id,
+      request_digest: "9d29429ce1a103db51351b4d136306a00fb8dc77ae392b506ba09e625073c725",
+      tag_id: tag.id, assign: true, tag_revision: 3, assignment_count: 2,
+      completed_at: "2026-09-11T00:00:00.000000000Z",
+      nodes: [{ node_id: 7, expected_revision: 3, revision: 3, changed: false }, { node_id: 9, expected_revision: 4, revision: 5, changed: true }],
+    }), { status: 200 });
+  });
+  render(BatchTagsModal, { session: "session", targets, catalog: [tag], catalogTotal: 1,
+    disabled: false, onclose: vi.fn(), onchanged, onauthfailure: vi.fn() });
+  await chooseTag();
+  await screen.findByText("1 of 2 selected documents have this tag.");
+  expect((screen.getByRole("checkbox", { name: "Selected tag membership" }) as HTMLInputElement).indeterminate).toBe(true);
+  await fireEvent.click(screen.getByRole("button", { name: "Add to all" }));
+  await screen.findByRole("button", { name: "Retry same operation" });
+  expect(onchanged).not.toHaveBeenCalled();
+  expect((screen.getByRole("button", { name: "Remove from all" }) as HTMLButtonElement).disabled).toBe(true);
+  await fireEvent.click(screen.getByRole("button", { name: "Retry same operation" }));
+  await waitFor(() => expect(onchanged).toHaveBeenCalledTimes(1));
+  expect(requests).toHaveLength(2);
+  expect(requests[1]).toEqual(requests[0]);
+  await screen.findByText("2 of 2 selected documents have this tag.");
+});
+
+it("requires explicit reselection after a stale preview", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ detail: "Selection is stale", code: "stale_revision" }), { status: 409 }));
+  const onclose = vi.fn();
+  render(BatchTagsModal, { session: "session", targets, catalog: [tag], catalogTotal: 3,
+    disabled: false, onclose, onchanged: vi.fn(), onauthfailure: vi.fn() });
+  await chooseTag();
+  await screen.findByText(/Close and refresh your selection/);
+  expect((screen.getByRole("button", { name: "Add to all" }) as HTMLButtonElement).disabled).toBe(true);
+  await fireEvent.click(screen.getByRole("button", { name: "Done" }));
+  expect(onclose).toHaveBeenCalledOnce();
+});

--- a/frontend/src/SelectionDock.svelte
+++ b/frontend/src/SelectionDock.svelte
@@ -7,6 +7,7 @@
     truncated: boolean;
     onclear: () => void;
     onselectvisible: () => void;
+    ontags?: () => void;
   }
 
   let {
@@ -15,6 +16,7 @@
     truncated,
     onclear,
     onselectvisible,
+    ontags,
   }: Props = $props();
 </script>
 
@@ -43,6 +45,9 @@
       onclick={onselectvisible}
     >Select visible documents</Button>
     <Button size="sm" onclick={onclear}>Clear selection</Button>
+    {#if ontags}
+      <Button size="sm" onclick={ontags}>Add tags</Button>
+    {/if}
   </div>
 </BottomDock>
 

--- a/frontend/src/SelectionDock.svelte
+++ b/frontend/src/SelectionDock.svelte
@@ -8,6 +8,7 @@
     onclear: () => void;
     onselectvisible: () => void;
     ontags?: () => void;
+    tagsDisabled?: boolean;
   }
 
   let {
@@ -17,6 +18,7 @@
     onclear,
     onselectvisible,
     ontags,
+    tagsDisabled = false,
   }: Props = $props();
 </script>
 
@@ -46,7 +48,7 @@
     >Select visible documents</Button>
     <Button size="sm" onclick={onclear}>Clear selection</Button>
     {#if ontags}
-      <Button size="sm" onclick={ontags}>Add tags</Button>
+      <Button size="sm" disabled={tagsDisabled} onclick={ontags}>Edit tags</Button>
     {/if}
   </div>
 </BottomDock>

--- a/frontend/src/SelectionDock.test.ts
+++ b/frontend/src/SelectionDock.test.ts
@@ -63,3 +63,18 @@ it("uses the dock close control to clear selection", async () => {
   );
   expect(onclear).toHaveBeenCalledOnce();
 });
+
+it("offers the bounded tag action when supplied", async () => {
+  const ontags = vi.fn();
+  render(SelectionDock, {
+    selectedCount: 2,
+    visibleDocumentCount: 3,
+    truncated: false,
+    onclear: vi.fn(),
+    onselectvisible: vi.fn(),
+    ontags,
+  });
+
+  await fireEvent.click(screen.getByRole("button", { name: "Add tags" }));
+  expect(ontags).toHaveBeenCalledOnce();
+});

--- a/frontend/src/SelectionDock.test.ts
+++ b/frontend/src/SelectionDock.test.ts
@@ -66,15 +66,18 @@ it("uses the dock close control to clear selection", async () => {
 
 it("offers the bounded tag action when supplied", async () => {
   const ontags = vi.fn();
-  render(SelectionDock, {
+  const { rerender } = render(SelectionDock, {
     selectedCount: 2,
     visibleDocumentCount: 3,
     truncated: false,
     onclear: vi.fn(),
     onselectvisible: vi.fn(),
     ontags,
+    tagsDisabled: true,
   });
 
-  await fireEvent.click(screen.getByRole("button", { name: "Add tags" }));
+  expect((screen.getByRole("button", { name: "Edit tags" }) as HTMLButtonElement).disabled).toBe(true);
+  await rerender({ tagsDisabled: false });
+  await fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
   expect(ontags).toHaveBeenCalledOnce();
 });

--- a/frontend/src/batch-tags.test.ts
+++ b/frontend/src/batch-tags.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  batchTagRequestDigest, changeBatchTags, previewBatchTags,
+  validateBatchTagReceipt, type BatchTagRequest, type BatchTagReceipt,
+} from "./batch-tags.js";
+
+const request: BatchTagRequest = {
+  operation_id: "11111111-1111-4111-8111-111111111111",
+  tag_id: "22222222-2222-4222-8222-222222222222",
+  assign: true,
+  nodes: [{ node_id: 9, revision: 4 }, { node_id: 7, revision: 3 }],
+};
+const receipt: BatchTagReceipt = {
+  version: 1, operation_id: request.operation_id, tag_id: request.tag_id, assign: true,
+  request_digest: "9d29429ce1a103db51351b4d136306a00fb8dc77ae392b506ba09e625073c725",
+  tag_revision: 3, assignment_count: 2, completed_at: "2026-09-11T00:00:00.000000000Z",
+  nodes: [
+    { node_id: 7, expected_revision: 3, revision: 4, changed: true },
+    { node_id: 9, expected_revision: 4, revision: 4, changed: false },
+  ],
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("batch tag request and receipt identity", () => {
+  it("uses the cross-language digest grammar independent of display order", async () => {
+    expect(await batchTagRequestDigest(request)).toBe(receipt.request_digest);
+    expect(await batchTagRequestDigest({ ...request, nodes: [...request.nodes].reverse() })).toBe(receipt.request_digest);
+    expect(await batchTagRequestDigest({ ...request, assign: false })).not.toBe(receipt.request_digest);
+    expect(request.nodes[0].node_id).toBe(9);
+  });
+
+  it("accepts complete changed and no-op results", async () => {
+    await expect(validateBatchTagReceipt(request, receipt)).resolves.toEqual(receipt);
+  });
+
+  it.each([
+    { ...receipt, nodes: [] },
+    { ...receipt, nodes: [receipt.nodes[0], receipt.nodes[0]] },
+    { ...receipt, nodes: [{ ...receipt.nodes[0], node_id: 8 }, receipt.nodes[1]] },
+    { ...receipt, nodes: [{ ...receipt.nodes[0], revision: 3 }, receipt.nodes[1]] },
+    { ...receipt, nodes: [receipt.nodes[0], { ...receipt.nodes[1], revision: 5 }] },
+    { ...receipt, assign: false },
+    { ...receipt, request_digest: "0".repeat(64) },
+    { ...receipt, operation_id: request.tag_id },
+    { ...receipt, tag_id: request.operation_id },
+    { ...receipt, tag_revision: Number.MAX_SAFE_INTEGER + 1 },
+    { ...receipt, assignment_count: -1 },
+    { ...receipt, completed_at: "2026-02-30T00:00:00.000000000Z" },
+    { ...receipt, version: 2 },
+    null,
+  ])("rejects incomplete or substituted receipts %#", async (invalid) => {
+    await expect(validateBatchTagReceipt(request, invalid)).rejects.toThrow();
+  });
+
+  it("rejects malformed requests before egress", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch");
+    for (const nodes of [[], [request.nodes[0], request.nodes[0]], [{ node_id: 7, revision: 0 }], [{ node_id: Number.MAX_SAFE_INTEGER + 1, revision: 1 }]]) {
+      await expect(changeBatchTags("session", { ...request, nodes })).rejects.toThrow();
+    }
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the exact request available after response loss", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("Synthetic response loss"))
+      .mockResolvedValueOnce(new Response(JSON.stringify(receipt), { status: 200 }));
+    await expect(changeBatchTags("session", request)).rejects.toThrow("Synthetic response loss");
+    await expect(changeBatchTags("session", request)).resolves.toEqual(receipt);
+    expect(fetch.mock.calls[0][1]?.body).toBe(fetch.mock.calls[1][1]?.body);
+    expect(new Headers(fetch.mock.calls[1][1]?.headers).get("Content-Type")).toBe("application/json");
+    expect(JSON.parse(String(fetch.mock.calls[1][1]?.body)).operation_id).toBe(request.operation_id);
+  });
+
+  it("refuses partial preview membership", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      tag_id: request.tag_id, tag_revision: 3,
+      nodes: [{ node_id: 7, revision: 3, assigned: true }],
+    }), { status: 200 }));
+    await expect(previewBatchTags("session", request.tag_id, request.nodes)).rejects.toThrow();
+  });
+
+  it("returns exact mixed preview identities", async () => {
+    const preview = { tag_id: request.tag_id, tag_revision: 3, nodes: [
+      { node_id: 7, revision: 3, assigned: true },
+      { node_id: 9, revision: 4, assigned: false },
+    ] };
+    const fetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify(preview), { status: 200 }));
+    await expect(previewBatchTags("session", request.tag_id, request.nodes)).resolves.toEqual(preview);
+    expect(new Headers(fetch.mock.calls[0][1]?.headers).get("Content-Type")).toBe("application/json");
+  });
+});

--- a/frontend/src/batch-tags.ts
+++ b/frontend/src/batch-tags.ts
@@ -1,11 +1,11 @@
 import { requestJSON } from "./api.js";
+import type { SelectionTarget } from "./selection.js";
 
-export interface BatchTagTarget { node_id: number; revision: number }
 export interface BatchTagRequest {
   operation_id: string;
   tag_id: string;
   assign: boolean;
-  nodes: BatchTagTarget[];
+  nodes: SelectionTarget[];
 }
 export interface BatchTagNodeResult {
   node_id: number;
@@ -44,7 +44,7 @@ function validUUID(value: unknown): value is string {
   return typeof value === "string" && uuidV4.test(value);
 }
 
-function canonicalTargets(nodes: readonly BatchTagTarget[]): BatchTagTarget[] {
+function canonicalTargets(nodes: readonly SelectionTarget[]): SelectionTarget[] {
   if (!Array.isArray(nodes) || nodes.length < 1 || nodes.length > 1000) {
     throw new Error("Choose between 1 and 1,000 documents.");
   }
@@ -116,7 +116,7 @@ export async function changeBatchTags(session: string, request: BatchTagRequest)
   return validateBatchTagReceipt(normalized, value);
 }
 
-export async function previewBatchTags(session: string, tagID: string, targets: readonly BatchTagTarget[]): Promise<BatchTagPreview> {
+export async function previewBatchTags(session: string, tagID: string, targets: readonly SelectionTarget[]): Promise<BatchTagPreview> {
   if (!validUUID(tagID)) throw new Error("Choose a valid tag identity.");
   const nodes = canonicalTargets(targets);
   const value = await requestJSON<unknown>("/api/v1/batch/tags/preview", session, {

--- a/frontend/src/batch-tags.ts
+++ b/frontend/src/batch-tags.ts
@@ -1,0 +1,134 @@
+import { requestJSON } from "./api.js";
+
+export interface BatchTagTarget { node_id: number; revision: number }
+export interface BatchTagRequest {
+  operation_id: string;
+  tag_id: string;
+  assign: boolean;
+  nodes: BatchTagTarget[];
+}
+export interface BatchTagNodeResult {
+  node_id: number;
+  expected_revision: number;
+  revision: number;
+  changed: boolean;
+}
+export interface BatchTagReceipt {
+  version: number;
+  operation_id: string;
+  request_digest: string;
+  tag_id: string;
+  assign: boolean;
+  tag_revision: number;
+  assignment_count: number;
+  completed_at: string;
+  nodes: BatchTagNodeResult[];
+}
+export interface BatchTagPreview {
+  tag_id: string;
+  tag_revision: number;
+  nodes: { node_id: number; revision: number; assigned: boolean }[];
+}
+
+const uuidV4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function positiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validUUID(value: unknown): value is string {
+  return typeof value === "string" && uuidV4.test(value);
+}
+
+function canonicalTargets(nodes: readonly BatchTagTarget[]): BatchTagTarget[] {
+  if (!Array.isArray(nodes) || nodes.length < 1 || nodes.length > 1000) {
+    throw new Error("Choose between 1 and 1,000 documents.");
+  }
+  const seen = new Set<number>();
+  const result = nodes.map((node) => {
+    if (!record(node) || !positiveInteger(node.node_id) || !positiveInteger(node.revision) || seen.has(node.node_id)) {
+      throw new Error("Selected documents need unique identities and valid revisions.");
+    }
+    seen.add(node.node_id);
+    return { node_id: node.node_id, revision: node.revision };
+  });
+  return result.sort((left, right) => left.node_id - right.node_id);
+}
+
+function canonicalRequest(request: BatchTagRequest): BatchTagRequest {
+  if (!record(request) || !validUUID(request.operation_id) || !validUUID(request.tag_id) || typeof request.assign !== "boolean") {
+    throw new Error("The tag operation has an invalid identity or action.");
+  }
+  return { operation_id: request.operation_id, tag_id: request.tag_id,
+    assign: request.assign, nodes: canonicalTargets(request.nodes) };
+}
+
+export async function batchTagRequestDigest(request: BatchTagRequest): Promise<string> {
+  const normalized = canonicalRequest(request);
+  const text = `docbank-tag-batch-v1\n${normalized.tag_id}\n${normalized.assign ? "1" : "0"}\n` +
+    normalized.nodes.map((node) => `${node.node_id}:${node.revision}\n`).join("");
+  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return Array.from(new Uint8Array(hash), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function canonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{9}Z$/.test(value)) return false;
+  const milliseconds = value.slice(0, 23) + "Z";
+  const parsed = new Date(milliseconds);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === milliseconds;
+}
+
+export async function validateBatchTagReceipt(request: BatchTagRequest, value: unknown): Promise<BatchTagReceipt> {
+  const normalized = canonicalRequest(request);
+  const invalid = () => new Error("The daemon returned an invalid batch tag receipt. The outcome is not confirmed; retry the same operation.");
+  if (!record(value) || value.version !== 1 || value.operation_id !== normalized.operation_id ||
+      value.tag_id !== normalized.tag_id || value.assign !== normalized.assign ||
+      !positiveInteger(value.tag_revision) || typeof value.assignment_count !== "number" ||
+      !Number.isSafeInteger(value.assignment_count) || value.assignment_count < 0 ||
+      !canonicalTimestamp(value.completed_at) || !Array.isArray(value.nodes) ||
+      value.nodes.length !== normalized.nodes.length) throw invalid();
+  let changed = 0;
+  for (let index = 0; index < normalized.nodes.length; index++) {
+    const expected = normalized.nodes[index];
+    const actual: unknown = value.nodes[index];
+    if (!record(actual) || actual.node_id !== expected.node_id ||
+        actual.expected_revision !== expected.revision || typeof actual.changed !== "boolean" ||
+        !positiveInteger(actual.revision) || actual.revision !== expected.revision + (actual.changed ? 1 : 0)) throw invalid();
+    if (actual.changed) changed++;
+  }
+  if (value.tag_revision <= changed || (normalized.assign && value.assignment_count < normalized.nodes.length) ||
+      value.request_digest !== await batchTagRequestDigest(normalized)) throw invalid();
+  return value as unknown as BatchTagReceipt;
+}
+
+export async function changeBatchTags(session: string, request: BatchTagRequest): Promise<BatchTagReceipt> {
+  const normalized = canonicalRequest(request);
+  // Compute before egress so unavailable local crypto cannot turn a committed
+  // operation into an avoidable client-validation failure.
+  await batchTagRequestDigest(normalized);
+  const value = await requestJSON<unknown>("/api/v1/batch/tags", session, {
+    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(normalized),
+  });
+  return validateBatchTagReceipt(normalized, value);
+}
+
+export async function previewBatchTags(session: string, tagID: string, targets: readonly BatchTagTarget[]): Promise<BatchTagPreview> {
+  if (!validUUID(tagID)) throw new Error("Choose a valid tag identity.");
+  const nodes = canonicalTargets(targets);
+  const value = await requestJSON<unknown>("/api/v1/batch/tags/preview", session, {
+    method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ tag_id: tagID, nodes }),
+  });
+  const invalid = () => new Error("The daemon returned an incomplete or invalid tag membership preview.");
+  if (!record(value) || value.tag_id !== tagID || !positiveInteger(value.tag_revision) ||
+      !Array.isArray(value.nodes) || value.nodes.length !== nodes.length) throw invalid();
+  for (let index = 0; index < nodes.length; index++) {
+    const actual: unknown = value.nodes[index];
+    if (!record(actual) || actual.node_id !== nodes[index].node_id ||
+        actual.revision !== nodes[index].revision || typeof actual.assigned !== "boolean") throw invalid();
+  }
+  return value as unknown as BatchTagPreview;
+}

--- a/frontend/src/selection.test.ts
+++ b/frontend/src/selection.test.ts
@@ -4,6 +4,7 @@ import {
   clearSelection,
   reconcileSelection,
   selectVisibleDocuments,
+  selectedTargets,
   toggleDocumentSelection,
   type SelectableRow,
 } from "./selection.js";
@@ -105,7 +106,7 @@ describe("document selection", () => {
     });
   });
 
-  it("reconciles removed IDs and the range anchor", () => {
+  it("reconciles removed IDs and derives targets from current revisions", () => {
     const visible = [row(2, "file", 20), row(3, "file", 30), row(4, "dir", 40)];
     const state = reconcileSelection(
       { selectedIDs: new Set([1, 2, 4]), anchorID: 1 },
@@ -113,5 +114,8 @@ describe("document selection", () => {
     );
     expect([...state.selectedIDs]).toEqual([2]);
     expect(state.anchorID).toBeUndefined();
+    expect(selectedTargets(visible, state.selectedIDs)).toEqual([
+      { node_id: 2, revision: 20 },
+    ]);
   });
 });

--- a/frontend/src/selection.ts
+++ b/frontend/src/selection.ts
@@ -7,6 +7,11 @@ export type SelectionState = {
   anchorID: number | undefined;
 };
 
+export type SelectionTarget = {
+  node_id: number;
+  revision: number;
+};
+
 function eligibleIDs(rows: readonly SelectableRow[]): number[] {
   return rows.filter((row) => row.node.kind === "file").map((row) => row.node.id);
 }
@@ -63,4 +68,12 @@ export function reconcileSelection(
         ? state.anchorID
         : undefined,
   };
+}
+export function selectedTargets(
+  rows: readonly SelectableRow[],
+  selectedIDs: ReadonlySet<number>,
+): SelectionTarget[] {
+  return rows
+    .filter((row) => row.node.kind === "file" && selectedIDs.has(row.node.id))
+    .map((row) => ({ node_id: row.node.id, revision: row.node.revision }));
 }

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -76,6 +76,8 @@ var storeErrCodes = []struct {
 	{store.ErrInvalidCollectionLabel, http.StatusUnprocessableEntity, "invalid_collection_label"},
 	{store.ErrInvalidDuplicatePage, http.StatusUnprocessableEntity, "invalid_duplicate_page"},
 	{store.ErrInvalidBatchMove, http.StatusUnprocessableEntity, "invalid_batch_move"},
+	{store.ErrInvalidBatchTag, http.StatusUnprocessableEntity, "invalid_batch_tag"},
+	{store.ErrBatchTagOperationConflict, http.StatusConflict, "batch_tag_operation_conflict"},
 	{store.ErrNotTrashed, http.StatusUnprocessableEntity, "not_trashed"},
 	{store.ErrIsRoot, http.StatusUnprocessableEntity, "is_root"},
 	{store.ErrVersionNodeMismatch, http.StatusUnprocessableEntity, "version_node_mismatch"},

--- a/internal/api/routes_batch_tags.go
+++ b/internal/api/routes_batch_tags.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/docbank/internal/store"
+)
+
+// BatchTagTarget binds an explicit selected identity to its observed revision.
+type BatchTagTarget struct {
+	NodeID   int64 `json:"node_id" minimum:"1"`
+	Revision int64 `json:"revision" minimum:"1"`
+}
+
+type BatchTagRequest struct {
+	OperationID string           `json:"operation_id" format:"uuid"`
+	TagID       string           `json:"tag_id" format:"uuid"`
+	Assign      bool             `json:"assign"`
+	Nodes       []BatchTagTarget `json:"nodes" minItems:"1" maxItems:"1000"`
+}
+
+type BatchTagNodeResult struct {
+	NodeID           int64 `json:"node_id" minimum:"1"`
+	ExpectedRevision int64 `json:"expected_revision" minimum:"1"`
+	Revision         int64 `json:"revision" minimum:"1"`
+	Changed          bool  `json:"changed"`
+}
+
+// BatchTagReceipt describes the original completed operation, not current state.
+type BatchTagReceipt struct {
+	Version         int                  `json:"version"`
+	OperationID     string               `json:"operation_id" format:"uuid"`
+	RequestDigest   string               `json:"request_digest" pattern:"^[0-9a-f]{64}$"`
+	TagID           string               `json:"tag_id" format:"uuid"`
+	Assign          bool                 `json:"assign"`
+	TagRevision     int64                `json:"tag_revision" minimum:"1"`
+	AssignmentCount int                  `json:"assignment_count" minimum:"0"`
+	CompletedAt     string               `json:"completed_at"`
+	Nodes           []BatchTagNodeResult `json:"nodes" minItems:"1" maxItems:"1000"`
+}
+
+type BatchTagPreviewNode struct {
+	NodeID   int64 `json:"node_id" minimum:"1"`
+	Revision int64 `json:"revision" minimum:"1"`
+	Assigned bool  `json:"assigned"`
+}
+
+type BatchTagPreview struct {
+	TagID       string                `json:"tag_id" format:"uuid"`
+	TagRevision int64                 `json:"tag_revision" minimum:"1"`
+	Nodes       []BatchTagPreviewNode `json:"nodes" minItems:"1" maxItems:"1000"`
+}
+
+func registerBatchTagRoutes(api huma.API, d Deps, g *gate) {
+	huma.Register(api, huma.Operation{
+		OperationID: "changeBatchTags", Method: http.MethodPost, Path: "/api/v1/batch/tags",
+		Summary: "Assign or remove one tag across an atomic selected set", MaxBodyBytes: 1 << 20,
+	}, func(ctx context.Context, in *struct{ Body BatchTagRequest }) (*struct{ Body BatchTagReceipt }, error) {
+		var receipt store.BatchTagReceipt
+		err := g.mutate(func() error {
+			var err error
+			receipt, err = d.Store.BatchTags(ctx, store.BatchTagRequest{
+				OperationID: in.Body.OperationID, TagID: in.Body.TagID, Assign: in.Body.Assign,
+				Nodes: batchTagStoreTargets(in.Body.Nodes),
+			})
+			return batchTagError(err)
+		})
+		if err != nil {
+			return nil, err
+		}
+		out := BatchTagReceipt{
+			Version: receipt.Version, OperationID: receipt.OperationID, RequestDigest: receipt.RequestDigest,
+			TagID: receipt.TagID, Assign: receipt.Assign, TagRevision: receipt.TagRevision,
+			AssignmentCount: receipt.AssignmentCount, CompletedAt: receipt.CompletedAt,
+			Nodes: make([]BatchTagNodeResult, 0, len(receipt.Nodes)),
+		}
+		for _, node := range receipt.Nodes {
+			out.Nodes = append(out.Nodes, BatchTagNodeResult{NodeID: node.NodeID,
+				ExpectedRevision: node.ExpectedRevision, Revision: node.Revision, Changed: node.Changed})
+		}
+		return &struct{ Body BatchTagReceipt }{Body: out}, nil
+	})
+	huma.Register(api, huma.Operation{
+		OperationID: "previewBatchTags", Method: http.MethodPost, Path: "/api/v1/batch/tags/preview",
+		Summary: "Observe exact tag membership for a revision-fenced selected set", MaxBodyBytes: 1 << 20,
+	}, func(ctx context.Context, in *struct {
+		Body struct {
+			TagID string           `json:"tag_id" format:"uuid"`
+			Nodes []BatchTagTarget `json:"nodes" minItems:"1" maxItems:"1000"`
+		}
+	}) (*struct{ Body BatchTagPreview }, error) {
+		preview, err := d.Store.PreviewBatchTags(ctx, in.Body.TagID, batchTagStoreTargets(in.Body.Nodes))
+		if err != nil {
+			return nil, batchTagError(err)
+		}
+		out := BatchTagPreview{TagID: preview.TagID, TagRevision: preview.TagRevision,
+			Nodes: make([]BatchTagPreviewNode, 0, len(preview.Nodes))}
+		for _, node := range preview.Nodes {
+			out.Nodes = append(out.Nodes, BatchTagPreviewNode{NodeID: node.NodeID, Revision: node.Revision, Assigned: node.Assigned})
+		}
+		return &struct{ Body BatchTagPreview }{Body: out}, nil
+	})
+}
+
+func batchTagStoreTargets(nodes []BatchTagTarget) []store.BatchTagTarget {
+	targets := make([]store.BatchTagTarget, len(nodes))
+	for i, node := range nodes {
+		targets[i] = store.BatchTagTarget{NodeID: node.NodeID, Revision: node.Revision}
+	}
+	return targets
+}
+
+func batchTagError(err error) error {
+	if errors.Is(err, store.ErrStaleRevision) {
+		return NewError(http.StatusConflict, "stale_revision", err.Error())
+	}
+	return FromStoreError(err)
+}

--- a/internal/api/routes_batch_tags.go
+++ b/internal/api/routes_batch_tags.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -59,14 +58,14 @@ func registerBatchTagRoutes(api huma.API, d Deps, g *gate) {
 		OperationID: "changeBatchTags", Method: http.MethodPost, Path: "/api/v1/batch/tags",
 		Summary: "Assign or remove one tag across an atomic selected set", MaxBodyBytes: 1 << 20,
 	}, func(ctx context.Context, in *struct{ Body BatchTagRequest }) (*struct{ Body BatchTagReceipt }, error) {
-		var receipt store.BatchTagReceipt
+		var receipt store.BatchTagReceiptV1
 		err := g.mutate(func() error {
 			var err error
 			receipt, err = d.Store.BatchTags(ctx, store.BatchTagRequest{
 				OperationID: in.Body.OperationID, TagID: in.Body.TagID, Assign: in.Body.Assign,
 				Nodes: batchTagStoreTargets(in.Body.Nodes),
 			})
-			return batchTagError(err)
+			return FromStoreError(err)
 		})
 		if err != nil {
 			return nil, err
@@ -94,7 +93,7 @@ func registerBatchTagRoutes(api huma.API, d Deps, g *gate) {
 	}) (*struct{ Body BatchTagPreview }, error) {
 		preview, err := d.Store.PreviewBatchTags(ctx, in.Body.TagID, batchTagStoreTargets(in.Body.Nodes))
 		if err != nil {
-			return nil, batchTagError(err)
+			return nil, FromStoreError(err)
 		}
 		out := BatchTagPreview{TagID: preview.TagID, TagRevision: preview.TagRevision,
 			Nodes: make([]BatchTagPreviewNode, 0, len(preview.Nodes))}
@@ -111,11 +110,4 @@ func batchTagStoreTargets(nodes []BatchTagTarget) []store.BatchTagTarget {
 		targets[i] = store.BatchTagTarget{NodeID: node.NodeID, Revision: node.Revision}
 	}
 	return targets
-}
-
-func batchTagError(err error) error {
-	if errors.Is(err, store.ErrStaleRevision) {
-		return NewError(http.StatusConflict, "stale_revision", err.Error())
-	}
-	return FromStoreError(err)
 }

--- a/internal/api/routes_batch_tags_backup_test.go
+++ b/internal/api/routes_batch_tags_backup_test.go
@@ -1,0 +1,70 @@
+package api_test
+
+import (
+	"encoding/json/v2"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/api"
+	"go.kenn.io/docbank/internal/client"
+	"go.kenn.io/docbank/internal/store"
+)
+
+func TestBatchTagReceiptSurvivesPhysicalBackupRestore(t *testing.T) {
+	for _, driver := range collectionBackupDrivers() {
+		t.Run(driver.Name(), func(t *testing.T) {
+			ts, live := newCollectionBackupServer(t, driver, filepath.Join(t.TempDir(), "repository"))
+			node, err := live.Mkdir(t.Context(), live.RootID(), "selected")
+			require.NoError(t, err)
+			tag, err := live.CreateTag(t.Context(), "Review")
+			require.NoError(t, err)
+			c := client.New(ts.URL, testAPIKey)
+			preview, err := c.PreviewAudit(t.Context(), client.AuditPreviewOptions{NodeID: live.RootID(), AgentLabel: "batch-tag-backup-test"})
+			require.NoError(t, err)
+			_, err = c.EnableAudit(t.Context(), preview.PreviewToken, true)
+			require.NoError(t, err)
+			node, err = live.NodeByID(t.Context(), node.ID)
+			require.NoError(t, err)
+			request := store.BatchTagRequest{OperationID: "11111111-1111-4111-8111-111111111111", TagID: tag.ID, Assign: true,
+				Nodes: []store.BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}}}
+			original, err := live.BatchTags(t.Context(), request)
+			require.NoError(t, err)
+			resp, body := do(t, ts, http.MethodPost, "/api/v1/backup/init", nil, map[string]any{})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/snapshots", nil, map[string]any{"tag": "batch-tag-receipt", "jobs": 1})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			var snapshot api.BackupSnapshot
+			require.NoError(t, json.Unmarshal([]byte(body), &snapshot))
+			target := filepath.Join(t.TempDir(), "restored")
+			resp, body = do(t, ts, http.MethodPost, "/api/v1/backup/restore/stream", nil,
+				map[string]any{"target": target, "snapshot_id": snapshot.ID, "jobs": 1})
+			require.Equal(t, http.StatusOK, resp.StatusCode, body)
+			events := decodeBackupRestoreEvents(t, body)
+			require.NotEmpty(t, events)
+			terminal := events[len(events)-1]
+			require.Equal(t, "result", terminal.Type)
+			require.NotNil(t, terminal.Report)
+			require.True(t, terminal.Report.Proof.ContentVerified)
+			restored, err := store.Open(filepath.Join(target, "docbank.db"), driver)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, restored.Close()) }()
+			before, err := restored.AuditHistory(t.Context(), node.ID, 50, "")
+			require.NoError(t, err)
+			replay, err := restored.BatchTags(t.Context(), request)
+			require.NoError(t, err)
+			require.Equal(t, original, replay)
+			after, err := restored.AuditHistory(t.Context(), node.ID, 50, "")
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+			kinds := make([]string, 0, len(after.Items))
+			for _, event := range after.Items {
+				kinds = append(kinds, event.Kind)
+			}
+			require.Contains(t, kinds, "tag_assign")
+			_, err = restored.VerifyAudit(t.Context(), nil)
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/api/routes_batch_tags_test.go
+++ b/internal/api/routes_batch_tags_test.go
@@ -21,7 +21,12 @@ func TestBatchTagsHTTPReplayAndStaleAtomicity(t *testing.T) {
 	targets := []map[string]any{{"node_id": one.ID, "revision": one.Revision}, {"node_id": two.ID, "revision": two.Revision + 1}}
 	request := map[string]any{"operation_id": "11111111-1111-4111-8111-111111111111", "tag_id": tag.ID, "assign": true, "nodes": targets}
 	resp, body := do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
-	require.Equal(t, http.StatusConflict, resp.StatusCode, body)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode, body)
+	require.Contains(t, body, `"code":"stale_revision"`)
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags/preview", nil,
+		map[string]any{"tag_id": tag.ID, "nodes": targets})
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode, body)
+	require.Contains(t, body, `"code":"stale_revision"`)
 	after, err := s.NodeByID(ctx, one.ID)
 	require.NoError(t, err)
 	require.Equal(t, one.Revision, after.Revision)

--- a/internal/api/routes_batch_tags_test.go
+++ b/internal/api/routes_batch_tags_test.go
@@ -1,0 +1,164 @@
+package api_test
+
+import (
+	"encoding/json/v2"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank/internal/api"
+)
+
+func TestBatchTagsHTTPReplayAndStaleAtomicity(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	ctx := t.Context()
+	one, err := s.Mkdir(ctx, s.RootID(), "one")
+	require.NoError(t, err)
+	two, err := s.Mkdir(ctx, s.RootID(), "two")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(ctx, "Review")
+	require.NoError(t, err)
+	targets := []map[string]any{{"node_id": one.ID, "revision": one.Revision}, {"node_id": two.ID, "revision": two.Revision + 1}}
+	request := map[string]any{"operation_id": "11111111-1111-4111-8111-111111111111", "tag_id": tag.ID, "assign": true, "nodes": targets}
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusConflict, resp.StatusCode, body)
+	after, err := s.NodeByID(ctx, one.ID)
+	require.NoError(t, err)
+	require.Equal(t, one.Revision, after.Revision)
+	targets[1]["revision"] = two.Revision
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var receipt struct {
+		OperationID     string `json:"operation_id"`
+		TagID           string `json:"tag_id"`
+		Assign          bool   `json:"assign"`
+		TagRevision     int64  `json:"tag_revision"`
+		AssignmentCount int    `json:"assignment_count"`
+		Nodes           []struct {
+			NodeID           int64 `json:"node_id"`
+			ExpectedRevision int64 `json:"expected_revision"`
+			Revision         int64 `json:"revision"`
+			Changed          bool  `json:"changed"`
+		} `json:"nodes"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &receipt))
+	require.Equal(t, request["operation_id"], receipt.OperationID)
+	require.Equal(t, tag.ID, receipt.TagID)
+	require.True(t, receipt.Assign)
+	require.Equal(t, tag.Revision+2, receipt.TagRevision)
+	require.Equal(t, 2, receipt.AssignmentCount)
+	require.Len(t, receipt.Nodes, 2)
+	require.Equal(t, one.ID, receipt.Nodes[0].NodeID)
+	require.Equal(t, two.ID, receipt.Nodes[1].NodeID)
+	for _, result := range receipt.Nodes {
+		require.True(t, result.Changed)
+		require.Equal(t, result.ExpectedRevision+1, result.Revision)
+	}
+	_, err = s.UnassignTag(ctx, tag.ID, one.ID, receipt.Nodes[0].Revision)
+	require.NoError(t, err)
+	resp, replay := do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusOK, resp.StatusCode, replay)
+	require.JSONEq(t, body, replay)
+	request["assign"] = false
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusConflict, resp.StatusCode, body)
+	require.Contains(t, body, "batch_tag_operation_conflict")
+}
+
+func TestBatchTagsHTTPValidationAndPreview(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	node, err := s.Mkdir(t.Context(), s.RootID(), "selected")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(t.Context(), "Review")
+	require.NoError(t, err)
+	request := map[string]any{"operation_id": "11111111-1111-4111-8111-111111111111", "tag_id": tag.ID, "nodes": []map[string]any{{"node_id": node.ID, "revision": node.Revision}}}
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	request["assign"] = false
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(body), &result))
+	require.Equal(t, false, result["assign"])
+	preview := map[string]any{"tag_id": tag.ID, "nodes": request["nodes"]}
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags/preview", nil, preview)
+	require.Equal(t, http.StatusOK, resp.StatusCode, body)
+	var observed struct {
+		Nodes []struct {
+			NodeID   int64 `json:"node_id"`
+			Revision int64 `json:"revision"`
+			Assigned bool  `json:"assigned"`
+		} `json:"nodes"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &observed))
+	require.Len(t, observed.Nodes, 1)
+	require.Equal(t, node.ID, observed.Nodes[0].NodeID)
+	require.Equal(t, node.Revision, observed.Nodes[0].Revision)
+	require.False(t, observed.Nodes[0].Assigned)
+	for _, nodes := range []any{[]any{}, []map[string]any{{"node_id": node.ID, "revision": 0}}, []map[string]any{{"node_id": node.ID, "revision": node.Revision}, {"node_id": node.ID, "revision": node.Revision}}} {
+		request["nodes"] = nodes
+		resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+		require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	}
+}
+
+func TestBatchTagsHTTPBrowserCapabilityIsExact(t *testing.T) {
+	ts, _ := newTestServer(t, nil)
+	resp, body := do(t, ts, http.MethodPost, "/api/daemon/web-session", nil, nil)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, body)
+	var session struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &session))
+	headers := map[string]string{"X-Api-Key": "", api.WebSessionHeader: session.Token}
+	for _, path := range []string{"/api/v1/batch/tags", "/api/v1/batch/tags/preview"} {
+		resp, body = do(t, ts, http.MethodPost, path, headers, map[string]any{})
+		require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+		resp, body = do(t, ts, http.MethodPost, path, map[string]string{"X-Api-Key": ""}, map[string]any{})
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode, body)
+		for _, suffix := range []string{"?extra=true", "/extra"} {
+			resp, body = do(t, ts, http.MethodPost, path+suffix, headers, map[string]any{})
+			require.Equal(t, http.StatusForbidden, resp.StatusCode, body)
+		}
+		resp, body = do(t, ts, http.MethodDelete, path, headers, nil)
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, body)
+	}
+}
+
+func TestBatchTagsHTTPBoundsAndUnavailableTargets(t *testing.T) {
+	ts, s := newTestServer(t, nil)
+	node, err := s.Mkdir(t.Context(), s.RootID(), "selected")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(t.Context(), "Review")
+	require.NoError(t, err)
+	request := map[string]any{"operation_id": "11111111-1111-4111-8111-111111111111", "tag_id": tag.ID, "assign": true,
+		"nodes": []map[string]any{{"node_id": node.ID, "revision": node.Revision}}}
+	for _, field := range []string{"operation_id", "tag_id", "assign", "nodes"} {
+		original := request[field]
+		request[field] = nil
+		resp, body := do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+		require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+		request[field] = original
+	}
+	tooMany := make([]map[string]any, 1001)
+	for i := range tooMany {
+		tooMany[i] = map[string]any{"node_id": i + 1, "revision": 1}
+	}
+	request["nodes"] = tooMany
+	resp, body := do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode, body)
+	request["nodes"] = []map[string]any{{"node_id": 999999, "revision": 1}}
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode, body)
+	trashed, _, err := s.Trash(t.Context(), node.ID, node.Revision)
+	require.NoError(t, err)
+	request["nodes"] = []map[string]any{{"node_id": node.ID, "revision": trashed.Revision}}
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode, body)
+	preview := map[string]any{"tag_id": tag.ID, "nodes": request["nodes"]}
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags/preview", nil, preview)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode, body)
+	require.NoError(t, s.Close())
+	resp, body = do(t, ts, http.MethodPost, "/api/v1/batch/tags", nil, request)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode, body)
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -142,6 +142,7 @@ func NewServer(d Deps) *Server {
 	registerContentPruneRoute(humaAPI, d, g)
 	registerProvenanceRoutes(humaAPI, d, g)
 	registerTagRoutes(humaAPI, d, g)
+	registerBatchTagRoutes(humaAPI, d, g)
 	registerSavedQueryRoutes(humaAPI, d, g)
 	registerAuditRoutes(humaAPI, d, g, s.auditPreviews)
 	clearLongRunningBodyReadDeadlines(humaAPI)

--- a/internal/api/web_session.go
+++ b/internal/api/web_session.go
@@ -172,6 +172,9 @@ func (r *webSessionRegistry) closeAll(ctx context.Context) error {
 
 func webSessionRequestAllowed(r *http.Request) bool {
 	method, path := r.Method, r.URL.Path
+	if path == "/api/v1/batch/tags" || path == "/api/v1/batch/tags/preview" {
+		return method == http.MethodPost && r.URL.RawQuery == ""
+	}
 	if path == "/api/v1/saved-queries" {
 		return method == http.MethodGet ||
 			(method == http.MethodPost && r.URL.RawQuery == "")

--- a/internal/store/batch_tag.go
+++ b/internal/store/batch_tag.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -18,7 +19,7 @@ import (
 const (
 	maxBatchTagTargets          = 1000
 	maxBatchTagReceiptJSONBytes = 1 << 20
-	batchTagReceiptVersion      = 1
+	batchTagReceiptV1Version    = 1
 )
 
 var (
@@ -44,25 +45,26 @@ type BatchTagRequest struct {
 	Nodes       []BatchTagTarget `json:"nodes"`
 }
 
-// BatchTagNodeResult records one target's original fence and committed result.
-type BatchTagNodeResult struct {
+// BatchTagNodeResultV1 records one target's original fence and committed result.
+type BatchTagNodeResultV1 struct {
 	NodeID           int64 `json:"node_id"`
 	ExpectedRevision int64 `json:"expected_revision"`
 	Revision         int64 `json:"revision"`
 	Changed          bool  `json:"changed"`
 }
 
-// BatchTagReceipt is immutable replay authority for one committed operation.
-type BatchTagReceipt struct {
-	Version         int                  `json:"version"`
-	OperationID     string               `json:"operation_id"`
-	RequestDigest   string               `json:"request_digest"`
-	TagID           string               `json:"tag_id"`
-	Assign          bool                 `json:"assign"`
-	TagRevision     int64                `json:"tag_revision"`
-	AssignmentCount int                  `json:"assignment_count"`
-	CompletedAt     string               `json:"completed_at"`
-	Nodes           []BatchTagNodeResult `json:"nodes"`
+// BatchTagReceiptV1 is the frozen persisted v1 wire format. Keep its fields and
+// their order unchanged; future receipt formats need their own encoder and decoder.
+type BatchTagReceiptV1 struct {
+	Version         int                    `json:"version"`
+	OperationID     string                 `json:"operation_id"`
+	RequestDigest   string                 `json:"request_digest"`
+	TagID           string                 `json:"tag_id"`
+	Assign          bool                   `json:"assign"`
+	TagRevision     int64                  `json:"tag_revision"`
+	AssignmentCount int                    `json:"assignment_count"`
+	CompletedAt     string                 `json:"completed_at"`
+	Nodes           []BatchTagNodeResultV1 `json:"nodes"`
 }
 
 // BatchTagPreviewNode is one exact membership observation.
@@ -79,22 +81,21 @@ type BatchTagPreview struct {
 	Nodes       []BatchTagPreviewNode `json:"nodes"`
 }
 
-type plannedBatchTagTarget struct {
-	target  BatchTagTarget
-	node    Node
-	changed bool
+type batchTagTargetState struct {
+	node     Node
+	assigned bool
 }
 
 // BatchTags atomically applies one tag assignment choice to an exact bounded
 // set of live, revision-fenced nodes. A committed operation ID replays its
 // original immutable receipt without consulting current node or tag state.
-func (s *Store) BatchTags(ctx context.Context, request BatchTagRequest) (BatchTagReceipt, error) {
+func (s *Store) BatchTags(ctx context.Context, request BatchTagRequest) (BatchTagReceiptV1, error) {
 	targets, digest, err := validateBatchTagRequest(request)
 	if err != nil {
-		return BatchTagReceipt{}, err
+		return BatchTagReceiptV1{}, err
 	}
 
-	var receipt BatchTagReceipt
+	var receipt BatchTagReceiptV1
 	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
 		stored, found, err := loadBatchTagReceiptTx(ctx, tx, request.OperationID)
 		if err != nil {
@@ -112,78 +113,25 @@ func (s *Store) BatchTags(ctx context.Context, request BatchTagRequest) (BatchTa
 		if err != nil {
 			return err
 		}
-		planned := make([]plannedBatchTagTarget, len(targets))
-		changedCount := int64(0)
-		for i, target := range targets {
-			node, err := nodeByIDTx(tx, target.NodeID)
-			if err != nil {
-				return err
-			}
-			if node.TrashedAt != nil {
-				return fmt.Errorf("node %d is trashed: %w", node.ID, ErrNotFound)
-			}
-			if node.Revision != target.Revision {
-				return fmt.Errorf("node %d revision is %d, expected %d: %w",
-					node.ID, node.Revision, target.Revision, ErrStaleRevision)
-			}
-			assigned, err := batchTagAssignedTx(ctx, tx, request.TagID, node.ID)
-			if err != nil {
-				return err
-			}
-			changed := assigned != request.Assign
-			if changed && node.Revision == math.MaxInt64 {
-				return fmt.Errorf("node %d revision cannot advance beyond %d: %w",
-					node.ID, node.Revision, ErrInvalidBatchTag)
-			}
-			planned[i] = plannedBatchTagTarget{target: target, node: node, changed: changed}
-			if changed {
-				changedCount++
-			}
-		}
-		if changedCount > 0 && tag.Revision > math.MaxInt64-changedCount {
-			return fmt.Errorf("tag %s revision cannot advance by %d beyond %d: %w",
-				tag.ID, changedCount, math.MaxInt64, ErrInvalidBatchTag)
-		}
-
-		active, err := auditAuthorityActiveTx(ctx, tx)
+		states, err := loadBatchTagTargetsTx(ctx, tx, request.TagID, targets)
 		if err != nil {
 			return err
 		}
-		results := make([]BatchTagNodeResult, len(planned))
-		recordedAt := nowRFC3339()
-		for i, item := range planned {
-			var change TagAssignmentChange
-			if active {
-				change, err = s.changeAuditedTagAssignmentTx(
-					ctx, tx, request.TagID, item.node, item.target.Revision, request.Assign,
-				)
-			} else {
-				change, err = changeTagAssignmentTx(
-					ctx, tx, request.TagID, item.node, item.target.Revision, request.Assign, recordedAt,
-				)
-			}
-			if err != nil {
-				return err
-			}
-			if change.Changed != item.changed {
-				return fmt.Errorf("node %d assignment changed after batch validation", item.node.ID)
-			}
-			results[i] = BatchTagNodeResult{
-				NodeID: item.node.ID, ExpectedRevision: item.target.Revision,
-				Revision: change.Node.Revision, Changed: change.Changed,
-			}
+		results, err := s.applyBatchTagsTx(ctx, tx, request, tag, states, nowRFC3339())
+		if err != nil {
+			return err
 		}
 		finalTag, err := tagByIDTx(tx, request.TagID)
 		if err != nil {
 			return err
 		}
-		receipt = BatchTagReceipt{
-			Version: batchTagReceiptVersion, OperationID: request.OperationID,
+		receipt = BatchTagReceiptV1{
+			Version: batchTagReceiptV1Version, OperationID: request.OperationID,
 			RequestDigest: digest, TagID: request.TagID, Assign: request.Assign,
 			TagRevision: finalTag.Revision, AssignmentCount: finalTag.AssignmentCount,
 			CompletedAt: nowRFC3339(), Nodes: results,
 		}
-		receiptJSON, err := canonicalBatchTagReceiptJSON(receipt)
+		receiptJSON, err := canonicalBatchTagReceiptV1JSON(receipt)
 		if err != nil {
 			return fmt.Errorf("encoding batch tag receipt: %w", err)
 		}
@@ -195,7 +143,7 @@ func (s *Store) BatchTags(ctx context.Context, request BatchTagRequest) (BatchTa
 		return nil
 	})
 	if err != nil {
-		return BatchTagReceipt{}, err
+		return BatchTagReceiptV1{}, err
 	}
 	return receipt, nil
 }
@@ -222,24 +170,13 @@ func (s *Store) PreviewBatchTags(
 		TagID: tag.ID, TagRevision: tag.Revision,
 		Nodes: make([]BatchTagPreviewNode, len(targets)),
 	}
-	for i, target := range targets {
-		node, err := nodeByIDTx(tx, target.NodeID)
-		if err != nil {
-			return BatchTagPreview{}, err
-		}
-		if node.TrashedAt != nil {
-			return BatchTagPreview{}, fmt.Errorf("node %d is trashed: %w", node.ID, ErrNotFound)
-		}
-		if node.Revision != target.Revision {
-			return BatchTagPreview{}, fmt.Errorf("node %d revision is %d, expected %d: %w",
-				node.ID, node.Revision, target.Revision, ErrStaleRevision)
-		}
-		assigned, err := batchTagAssignedTx(ctx, tx, tagID, node.ID)
-		if err != nil {
-			return BatchTagPreview{}, err
-		}
+	states, err := loadBatchTagTargetsTx(ctx, tx, tagID, targets)
+	if err != nil {
+		return BatchTagPreview{}, err
+	}
+	for i, state := range states {
 		preview.Nodes[i] = BatchTagPreviewNode{
-			NodeID: node.ID, Revision: node.Revision, Assigned: assigned,
+			NodeID: state.node.ID, Revision: state.node.Revision, Assigned: state.assigned,
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -267,7 +204,7 @@ func validateBatchTagTargets(
 	}
 	targets := slices.Clone(nodes)
 	slices.SortFunc(targets, func(a, b BatchTagTarget) int {
-		return intCompare(a.NodeID, b.NodeID)
+		return cmp.Compare(a.NodeID, b.NodeID)
 	})
 	for i, target := range targets {
 		if target.NodeID < 1 || target.Revision < 1 {
@@ -280,16 +217,6 @@ func validateBatchTagTargets(
 		}
 	}
 	return targets, batchTagDigest(tagID, assign, targets), nil
-}
-
-func intCompare(a, b int64) int {
-	if a < b {
-		return -1
-	}
-	if a > b {
-		return 1
-	}
-	return 0
 }
 
 func batchTagDigest(tagID string, assign bool, targets []BatchTagTarget) string {
@@ -312,68 +239,177 @@ func batchTagDigest(tagID string, assign bool, targets []BatchTagTarget) string 
 	return hex.EncodeToString(digest[:])
 }
 
-func batchTagAssignedTx(ctx context.Context, tx *sql.Tx, tagID string, nodeID int64) (bool, error) {
-	var assigned bool
-	if err := tx.QueryRowContext(ctx,
-		`SELECT EXISTS(SELECT 1 FROM node_tags WHERE tag_id=? AND node_id=?)`,
-		tagID, nodeID,
-	).Scan(&assigned); err != nil {
-		return false, fmt.Errorf("checking tag %s assignment to node %d: %w", tagID, nodeID, err)
+func loadBatchTagTargetsTx(
+	ctx context.Context, tx *sql.Tx, tagID string, targets []BatchTagTarget,
+) ([]batchTagTargetState, error) {
+	args := make([]any, 1, len(targets)+1)
+	args[0] = tagID
+	for _, target := range targets {
+		args = append(args, target.NodeID)
 	}
-	return assigned, nil
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(targets)), ",")
+	rows, err := tx.QueryContext(ctx, `SELECT `+nodeCols+`, nt.node_id IS NOT NULL
+		FROM `+nodeFrom+` LEFT JOIN node_tags nt ON nt.node_id=n.id AND nt.tag_id=?
+		WHERE n.id IN (`+placeholders+`) ORDER BY n.id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("reading batch tag targets: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	states := make([]batchTagTargetState, 0, len(targets))
+	for rows.Next() {
+		var state batchTagTargetState
+		n := &state.node
+		if err := rows.Scan(&n.ID, &n.ParentID, &n.Name, &n.Kind,
+			&n.CurrentVersionID, &n.BlobHash, &n.MD5, &n.Size, &n.MimeType,
+			&n.Revision, &n.CreatedAt, &n.ModifiedAt, &n.TrashedAt, &state.assigned); err != nil {
+			return nil, fmt.Errorf("scanning batch tag target: %w", err)
+		}
+		target := targets[len(states)]
+		if n.ID != target.NodeID || n.TrashedAt != nil {
+			return nil, fmt.Errorf("batch tag target %d is missing or trashed: %w", target.NodeID, ErrNotFound)
+		}
+		if n.Revision != target.Revision {
+			return nil, fmt.Errorf("node %d revision is %d, expected %d: %w",
+				n.ID, n.Revision, target.Revision, ErrStaleRevision)
+		}
+		states = append(states, state)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading batch tag targets: %w", err)
+	}
+	if len(states) != len(targets) {
+		return nil, fmt.Errorf("batch tag target %d: %w", targets[len(states)].NodeID, ErrNotFound)
+	}
+	return states, nil
+}
+
+func (s *Store) applyBatchTagsTx(
+	ctx context.Context, tx *sql.Tx, request BatchTagRequest, tag Tag,
+	states []batchTagTargetState, recordedAt string,
+) ([]BatchTagNodeResultV1, error) {
+	results := make([]BatchTagNodeResultV1, len(states))
+	changedIDs := make([]any, 0, len(states))
+	for i, state := range states {
+		node := state.node
+		changed := state.assigned != request.Assign
+		results[i] = BatchTagNodeResultV1{
+			NodeID: node.ID, ExpectedRevision: node.Revision, Revision: node.Revision, Changed: changed,
+		}
+		if changed {
+			if node.Revision == math.MaxInt64 {
+				return nil, fmt.Errorf("node %d revision cannot advance: %w", node.ID, ErrInvalidBatchTag)
+			}
+			results[i].Revision++
+			changedIDs = append(changedIDs, node.ID)
+		}
+	}
+	if len(changedIDs) == 0 {
+		return results, nil
+	}
+	if tag.Revision > math.MaxInt64-int64(len(changedIDs)) {
+		return nil, fmt.Errorf("tag %s revision cannot advance by %d: %w", tag.ID, len(changedIDs), ErrInvalidBatchTag)
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(changedIDs)), ",")
+	assignmentSQL := `DELETE FROM node_tags WHERE tag_id=? AND node_id IN (` + placeholders + `)`
+	if request.Assign {
+		assignmentSQL = `INSERT INTO node_tags(node_id,tag_id) SELECT id,? FROM nodes WHERE id IN (` + placeholders + `)`
+	}
+	if _, err := tx.ExecContext(ctx, assignmentSQL, append([]any{tag.ID}, changedIDs...)...); err != nil {
+		return nil, fmt.Errorf("changing batch tag assignments: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE nodes SET revision=revision+1,modified_at=?
+		WHERE id IN (`+placeholders+`)`, append([]any{recordedAt}, changedIDs...)...); err != nil {
+		return nil, fmt.Errorf("advancing batch tag nodes: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `UPDATE tags SET revision=revision+? WHERE id=?`, len(changedIDs), tag.ID); err != nil {
+		return nil, fmt.Errorf("advancing batch tag: %w", err)
+	}
+	active, err := auditAuthorityActiveTx(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if active {
+		for _, state := range states {
+			if state.assigned == request.Assign {
+				continue
+			}
+			if err := s.persistBatchTagAuditTx(ctx, tx, tag.ID, state.node, request.Assign, recordedAt); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return results, nil
+}
+
+func (s *Store) persistBatchTagAuditTx(
+	ctx context.Context, tx *sql.Tx, tagID string, prior Node, assign bool, recordedAt string,
+) error {
+	operationID, err := newUUIDv4()
+	if err != nil {
+		return err
+	}
+	authority, scopes, nodeSequence, err := loadAuditedNodeAuthority(ctx, tx, prior.ID)
+	if err != nil {
+		return err
+	}
+	result := prior
+	result.Revision++
+	result.ModifiedAt = recordedAt
+	return persistAuditedTagAssignment(ctx, tx, s.vaultID, operationID, recordedAt, nodeSequence,
+		authority, scopes, prior, result, tagID, assign)
 }
 
 func loadBatchTagReceiptTx(
 	ctx context.Context, tx *sql.Tx, operationID string,
-) (BatchTagReceipt, bool, error) {
+) (BatchTagReceiptV1, bool, error) {
 	var requestDigest string
 	var receiptJSON []byte
 	err := tx.QueryRowContext(ctx, `SELECT request_digest,receipt_json
 		FROM batch_tag_receipts WHERE operation_id=?`, operationID).Scan(&requestDigest, &receiptJSON)
 	if errors.Is(err, sql.ErrNoRows) {
-		return BatchTagReceipt{}, false, nil
+		return BatchTagReceiptV1{}, false, nil
 	}
 	if err != nil {
-		return BatchTagReceipt{}, false, fmt.Errorf("loading batch tag receipt %s: %w", operationID, err)
+		return BatchTagReceiptV1{}, false, fmt.Errorf("loading batch tag receipt %s: %w", operationID, err)
 	}
-	receipt, err := decodeBatchTagReceipt(receiptJSON)
+	receipt, err := decodeBatchTagReceiptV1(receiptJSON)
 	if err != nil {
-		return BatchTagReceipt{}, false, fmt.Errorf("validating batch tag receipt %s: %w", operationID, err)
+		return BatchTagReceiptV1{}, false, fmt.Errorf("validating batch tag receipt %s: %w", operationID, err)
 	}
 	if receipt.OperationID != operationID || receipt.RequestDigest != requestDigest {
-		return BatchTagReceipt{}, false, fmt.Errorf("batch tag receipt %s identity does not match its row", operationID)
+		return BatchTagReceiptV1{}, false, fmt.Errorf("batch tag receipt %s identity does not match its row", operationID)
 	}
 	return receipt, true, nil
 }
 
-func canonicalBatchTagReceiptJSON(receipt BatchTagReceipt) ([]byte, error) {
-	if err := validateBatchTagReceipt(receipt); err != nil {
+func canonicalBatchTagReceiptV1JSON(receipt BatchTagReceiptV1) ([]byte, error) {
+	if err := validateBatchTagReceiptV1(receipt); err != nil {
 		return nil, err
 	}
 	return json.Marshal(receipt, json.Deterministic(true))
 }
 
-func decodeBatchTagReceipt(data []byte) (BatchTagReceipt, error) {
+func decodeBatchTagReceiptV1(data []byte) (BatchTagReceiptV1, error) {
 	if len(data) == 0 || len(data) > maxBatchTagReceiptJSONBytes {
-		return BatchTagReceipt{}, fmt.Errorf("receipt JSON must be 1-%d bytes: %w",
+		return BatchTagReceiptV1{}, fmt.Errorf("receipt JSON must be 1-%d bytes: %w",
 			maxBatchTagReceiptJSONBytes, ErrInvalidBatchTag)
 	}
-	var receipt BatchTagReceipt
+	var receipt BatchTagReceiptV1
 	if err := json.Unmarshal(data, &receipt, json.RejectUnknownMembers(true)); err != nil {
-		return BatchTagReceipt{}, fmt.Errorf("decoding receipt: %w", err)
+		return BatchTagReceiptV1{}, fmt.Errorf("decoding receipt: %w", err)
 	}
-	canonical, err := canonicalBatchTagReceiptJSON(receipt)
+	canonical, err := canonicalBatchTagReceiptV1JSON(receipt)
 	if err != nil {
-		return BatchTagReceipt{}, err
+		return BatchTagReceiptV1{}, err
 	}
 	if !bytes.Equal(data, canonical) {
-		return BatchTagReceipt{}, errors.New("receipt JSON is not canonical")
+		return BatchTagReceiptV1{}, errors.New("receipt JSON is not canonical")
 	}
 	return receipt, nil
 }
 
-func validateBatchTagReceipt(receipt BatchTagReceipt) error {
-	if receipt.Version != batchTagReceiptVersion {
+func validateBatchTagReceiptV1(receipt BatchTagReceiptV1) error {
+	if receipt.Version != batchTagReceiptV1Version {
 		return fmt.Errorf("unsupported receipt version %d: %w", receipt.Version, ErrInvalidBatchTag)
 	}
 	if err := validateUUIDv4(receipt.OperationID); err != nil {

--- a/internal/store/batch_tag.go
+++ b/internal/store/batch_tag.go
@@ -1,0 +1,426 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+const (
+	maxBatchTagTargets          = 1000
+	maxBatchTagReceiptJSONBytes = 1 << 20
+	batchTagReceiptVersion      = 1
+)
+
+var (
+	// ErrInvalidBatchTag means a batch tag request or durable receipt violates
+	// the bounded canonical protocol.
+	ErrInvalidBatchTag = errors.New("invalid batch tag request")
+	// ErrBatchTagOperationConflict means an operation ID already names a
+	// different canonical request.
+	ErrBatchTagOperationConflict = errors.New("batch tag operation conflicts with existing receipt")
+)
+
+// BatchTagTarget identifies one exact node revision in a batch request.
+type BatchTagTarget struct {
+	NodeID   int64 `json:"node_id"`
+	Revision int64 `json:"revision"`
+}
+
+// BatchTagRequest names one replay-safe assignment or removal operation.
+type BatchTagRequest struct {
+	OperationID string           `json:"operation_id"`
+	TagID       string           `json:"tag_id"`
+	Assign      bool             `json:"assign"`
+	Nodes       []BatchTagTarget `json:"nodes"`
+}
+
+// BatchTagNodeResult records one target's original fence and committed result.
+type BatchTagNodeResult struct {
+	NodeID           int64 `json:"node_id"`
+	ExpectedRevision int64 `json:"expected_revision"`
+	Revision         int64 `json:"revision"`
+	Changed          bool  `json:"changed"`
+}
+
+// BatchTagReceipt is immutable replay authority for one committed operation.
+type BatchTagReceipt struct {
+	Version         int                  `json:"version"`
+	OperationID     string               `json:"operation_id"`
+	RequestDigest   string               `json:"request_digest"`
+	TagID           string               `json:"tag_id"`
+	Assign          bool                 `json:"assign"`
+	TagRevision     int64                `json:"tag_revision"`
+	AssignmentCount int                  `json:"assignment_count"`
+	CompletedAt     string               `json:"completed_at"`
+	Nodes           []BatchTagNodeResult `json:"nodes"`
+}
+
+// BatchTagPreviewNode is one exact membership observation.
+type BatchTagPreviewNode struct {
+	NodeID   int64 `json:"node_id"`
+	Revision int64 `json:"revision"`
+	Assigned bool  `json:"assigned"`
+}
+
+// BatchTagPreview is a bounded, revision-fenced tag membership snapshot.
+type BatchTagPreview struct {
+	TagID       string                `json:"tag_id"`
+	TagRevision int64                 `json:"tag_revision"`
+	Nodes       []BatchTagPreviewNode `json:"nodes"`
+}
+
+type plannedBatchTagTarget struct {
+	target  BatchTagTarget
+	node    Node
+	changed bool
+}
+
+// BatchTags atomically applies one tag assignment choice to an exact bounded
+// set of live, revision-fenced nodes. A committed operation ID replays its
+// original immutable receipt without consulting current node or tag state.
+func (s *Store) BatchTags(ctx context.Context, request BatchTagRequest) (BatchTagReceipt, error) {
+	targets, digest, err := validateBatchTagRequest(request)
+	if err != nil {
+		return BatchTagReceipt{}, err
+	}
+
+	var receipt BatchTagReceipt
+	err = s.withStorageTx(ctx, func(tx *sql.Tx) error {
+		stored, found, err := loadBatchTagReceiptTx(ctx, tx, request.OperationID)
+		if err != nil {
+			return err
+		}
+		if found {
+			if stored.RequestDigest != digest {
+				return fmt.Errorf("operation %s: %w", request.OperationID, ErrBatchTagOperationConflict)
+			}
+			receipt = stored
+			return nil
+		}
+
+		tag, err := tagByIDTx(tx, request.TagID)
+		if err != nil {
+			return err
+		}
+		planned := make([]plannedBatchTagTarget, len(targets))
+		changedCount := int64(0)
+		for i, target := range targets {
+			node, err := nodeByIDTx(tx, target.NodeID)
+			if err != nil {
+				return err
+			}
+			if node.TrashedAt != nil {
+				return fmt.Errorf("node %d is trashed: %w", node.ID, ErrNotFound)
+			}
+			if node.Revision != target.Revision {
+				return fmt.Errorf("node %d revision is %d, expected %d: %w",
+					node.ID, node.Revision, target.Revision, ErrStaleRevision)
+			}
+			assigned, err := batchTagAssignedTx(ctx, tx, request.TagID, node.ID)
+			if err != nil {
+				return err
+			}
+			changed := assigned != request.Assign
+			if changed && node.Revision == math.MaxInt64 {
+				return fmt.Errorf("node %d revision cannot advance beyond %d: %w",
+					node.ID, node.Revision, ErrInvalidBatchTag)
+			}
+			planned[i] = plannedBatchTagTarget{target: target, node: node, changed: changed}
+			if changed {
+				changedCount++
+			}
+		}
+		if changedCount > 0 && tag.Revision > math.MaxInt64-changedCount {
+			return fmt.Errorf("tag %s revision cannot advance by %d beyond %d: %w",
+				tag.ID, changedCount, math.MaxInt64, ErrInvalidBatchTag)
+		}
+
+		active, err := auditAuthorityActiveTx(ctx, tx)
+		if err != nil {
+			return err
+		}
+		results := make([]BatchTagNodeResult, len(planned))
+		recordedAt := nowRFC3339()
+		for i, item := range planned {
+			var change TagAssignmentChange
+			if active {
+				change, err = s.changeAuditedTagAssignmentTx(
+					ctx, tx, request.TagID, item.node, item.target.Revision, request.Assign,
+				)
+			} else {
+				change, err = changeTagAssignmentTx(
+					ctx, tx, request.TagID, item.node, item.target.Revision, request.Assign, recordedAt,
+				)
+			}
+			if err != nil {
+				return err
+			}
+			if change.Changed != item.changed {
+				return fmt.Errorf("node %d assignment changed after batch validation", item.node.ID)
+			}
+			results[i] = BatchTagNodeResult{
+				NodeID: item.node.ID, ExpectedRevision: item.target.Revision,
+				Revision: change.Node.Revision, Changed: change.Changed,
+			}
+		}
+		finalTag, err := tagByIDTx(tx, request.TagID)
+		if err != nil {
+			return err
+		}
+		receipt = BatchTagReceipt{
+			Version: batchTagReceiptVersion, OperationID: request.OperationID,
+			RequestDigest: digest, TagID: request.TagID, Assign: request.Assign,
+			TagRevision: finalTag.Revision, AssignmentCount: finalTag.AssignmentCount,
+			CompletedAt: nowRFC3339(), Nodes: results,
+		}
+		receiptJSON, err := canonicalBatchTagReceiptJSON(receipt)
+		if err != nil {
+			return fmt.Errorf("encoding batch tag receipt: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO batch_tag_receipts(
+			operation_id,request_digest,receipt_json) VALUES(?,?,?)`,
+			request.OperationID, digest, receiptJSON); err != nil {
+			return fmt.Errorf("persisting batch tag receipt %s: %w", request.OperationID, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return BatchTagReceipt{}, err
+	}
+	return receipt, nil
+}
+
+// PreviewBatchTags observes exact assignment membership for one bounded,
+// revision-fenced target set from a single read snapshot.
+func (s *Store) PreviewBatchTags(
+	ctx context.Context, tagID string, nodes []BatchTagTarget,
+) (BatchTagPreview, error) {
+	targets, _, err := validateBatchTagTargets(tagID, false, nodes)
+	if err != nil {
+		return BatchTagPreview{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return BatchTagPreview{}, fmt.Errorf("starting batch tag preview: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	tag, err := tagByIDTx(tx, tagID)
+	if err != nil {
+		return BatchTagPreview{}, err
+	}
+	preview := BatchTagPreview{
+		TagID: tag.ID, TagRevision: tag.Revision,
+		Nodes: make([]BatchTagPreviewNode, len(targets)),
+	}
+	for i, target := range targets {
+		node, err := nodeByIDTx(tx, target.NodeID)
+		if err != nil {
+			return BatchTagPreview{}, err
+		}
+		if node.TrashedAt != nil {
+			return BatchTagPreview{}, fmt.Errorf("node %d is trashed: %w", node.ID, ErrNotFound)
+		}
+		if node.Revision != target.Revision {
+			return BatchTagPreview{}, fmt.Errorf("node %d revision is %d, expected %d: %w",
+				node.ID, node.Revision, target.Revision, ErrStaleRevision)
+		}
+		assigned, err := batchTagAssignedTx(ctx, tx, tagID, node.ID)
+		if err != nil {
+			return BatchTagPreview{}, err
+		}
+		preview.Nodes[i] = BatchTagPreviewNode{
+			NodeID: node.ID, Revision: node.Revision, Assigned: assigned,
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return BatchTagPreview{}, fmt.Errorf("committing batch tag preview: %w", err)
+	}
+	return preview, nil
+}
+
+func validateBatchTagRequest(request BatchTagRequest) ([]BatchTagTarget, string, error) {
+	if err := validateUUIDv4(request.OperationID); err != nil {
+		return nil, "", fmt.Errorf("operation_id: %w: %w", err, ErrInvalidBatchTag)
+	}
+	return validateBatchTagTargets(request.TagID, request.Assign, request.Nodes)
+}
+
+func validateBatchTagTargets(
+	tagID string, assign bool, nodes []BatchTagTarget,
+) ([]BatchTagTarget, string, error) {
+	if err := validateUUIDv4(tagID); err != nil {
+		return nil, "", fmt.Errorf("tag_id: %w: %w", err, ErrInvalidBatchTag)
+	}
+	if len(nodes) < 1 || len(nodes) > maxBatchTagTargets {
+		return nil, "", fmt.Errorf("batch tag requires 1-%d nodes: %w",
+			maxBatchTagTargets, ErrInvalidBatchTag)
+	}
+	targets := slices.Clone(nodes)
+	slices.SortFunc(targets, func(a, b BatchTagTarget) int {
+		return intCompare(a.NodeID, b.NodeID)
+	})
+	for i, target := range targets {
+		if target.NodeID < 1 || target.Revision < 1 {
+			return nil, "", fmt.Errorf("batch tag node %d requires positive ID and revision: %w",
+				target.NodeID, ErrInvalidBatchTag)
+		}
+		if i > 0 && targets[i-1].NodeID == target.NodeID {
+			return nil, "", fmt.Errorf("batch tag repeats node %d: %w",
+				target.NodeID, ErrInvalidBatchTag)
+		}
+	}
+	return targets, batchTagDigest(tagID, assign, targets), nil
+}
+
+func intCompare(a, b int64) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+func batchTagDigest(tagID string, assign bool, targets []BatchTagTarget) string {
+	var input strings.Builder
+	input.WriteString("docbank-tag-batch-v1\n")
+	input.WriteString(tagID)
+	input.WriteByte('\n')
+	if assign {
+		input.WriteString("1\n")
+	} else {
+		input.WriteString("0\n")
+	}
+	for _, target := range targets {
+		input.WriteString(strconv.FormatInt(target.NodeID, 10))
+		input.WriteByte(':')
+		input.WriteString(strconv.FormatInt(target.Revision, 10))
+		input.WriteByte('\n')
+	}
+	digest := sha256.Sum256([]byte(input.String()))
+	return hex.EncodeToString(digest[:])
+}
+
+func batchTagAssignedTx(ctx context.Context, tx *sql.Tx, tagID string, nodeID int64) (bool, error) {
+	var assigned bool
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM node_tags WHERE tag_id=? AND node_id=?)`,
+		tagID, nodeID,
+	).Scan(&assigned); err != nil {
+		return false, fmt.Errorf("checking tag %s assignment to node %d: %w", tagID, nodeID, err)
+	}
+	return assigned, nil
+}
+
+func loadBatchTagReceiptTx(
+	ctx context.Context, tx *sql.Tx, operationID string,
+) (BatchTagReceipt, bool, error) {
+	var requestDigest string
+	var receiptJSON []byte
+	err := tx.QueryRowContext(ctx, `SELECT request_digest,receipt_json
+		FROM batch_tag_receipts WHERE operation_id=?`, operationID).Scan(&requestDigest, &receiptJSON)
+	if errors.Is(err, sql.ErrNoRows) {
+		return BatchTagReceipt{}, false, nil
+	}
+	if err != nil {
+		return BatchTagReceipt{}, false, fmt.Errorf("loading batch tag receipt %s: %w", operationID, err)
+	}
+	receipt, err := decodeBatchTagReceipt(receiptJSON)
+	if err != nil {
+		return BatchTagReceipt{}, false, fmt.Errorf("validating batch tag receipt %s: %w", operationID, err)
+	}
+	if receipt.OperationID != operationID || receipt.RequestDigest != requestDigest {
+		return BatchTagReceipt{}, false, fmt.Errorf("batch tag receipt %s identity does not match its row", operationID)
+	}
+	return receipt, true, nil
+}
+
+func canonicalBatchTagReceiptJSON(receipt BatchTagReceipt) ([]byte, error) {
+	if err := validateBatchTagReceipt(receipt); err != nil {
+		return nil, err
+	}
+	return json.Marshal(receipt, json.Deterministic(true))
+}
+
+func decodeBatchTagReceipt(data []byte) (BatchTagReceipt, error) {
+	if len(data) == 0 || len(data) > maxBatchTagReceiptJSONBytes {
+		return BatchTagReceipt{}, fmt.Errorf("receipt JSON must be 1-%d bytes: %w",
+			maxBatchTagReceiptJSONBytes, ErrInvalidBatchTag)
+	}
+	var receipt BatchTagReceipt
+	if err := json.Unmarshal(data, &receipt, json.RejectUnknownMembers(true)); err != nil {
+		return BatchTagReceipt{}, fmt.Errorf("decoding receipt: %w", err)
+	}
+	canonical, err := canonicalBatchTagReceiptJSON(receipt)
+	if err != nil {
+		return BatchTagReceipt{}, err
+	}
+	if !bytes.Equal(data, canonical) {
+		return BatchTagReceipt{}, errors.New("receipt JSON is not canonical")
+	}
+	return receipt, nil
+}
+
+func validateBatchTagReceipt(receipt BatchTagReceipt) error {
+	if receipt.Version != batchTagReceiptVersion {
+		return fmt.Errorf("unsupported receipt version %d: %w", receipt.Version, ErrInvalidBatchTag)
+	}
+	if err := validateUUIDv4(receipt.OperationID); err != nil {
+		return fmt.Errorf("receipt operation_id: %w: %w", err, ErrInvalidBatchTag)
+	}
+	if len(receipt.Nodes) < 1 || len(receipt.Nodes) > maxBatchTagTargets {
+		return fmt.Errorf("receipt requires 1-%d nodes: %w", maxBatchTagTargets, ErrInvalidBatchTag)
+	}
+	if receipt.TagRevision < 1 || receipt.AssignmentCount < 0 {
+		return fmt.Errorf("receipt has invalid final tag state: %w", ErrInvalidBatchTag)
+	}
+	if err := validateMetadataTime("batch tag completed_at", receipt.CompletedAt); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidBatchTag, err)
+	}
+	targets := make([]BatchTagTarget, len(receipt.Nodes))
+	changedCount := int64(0)
+	for i, node := range receipt.Nodes {
+		targets[i] = BatchTagTarget{NodeID: node.NodeID, Revision: node.ExpectedRevision}
+		if node.Changed {
+			changedCount++
+			if node.ExpectedRevision == math.MaxInt64 || node.Revision != node.ExpectedRevision+1 {
+				return fmt.Errorf("receipt node %d has invalid changed revision: %w",
+					node.NodeID, ErrInvalidBatchTag)
+			}
+		} else if node.Revision != node.ExpectedRevision {
+			return fmt.Errorf("receipt node %d has invalid unchanged revision: %w",
+				node.NodeID, ErrInvalidBatchTag)
+		}
+		if i > 0 && receipt.Nodes[i-1].NodeID >= node.NodeID {
+			return fmt.Errorf("receipt nodes are not strictly sorted: %w", ErrInvalidBatchTag)
+		}
+	}
+	if receipt.TagRevision <= changedCount {
+		return fmt.Errorf("receipt tag revision does not exceed changed node count: %w",
+			ErrInvalidBatchTag)
+	}
+	if receipt.Assign && receipt.AssignmentCount < len(receipt.Nodes) {
+		return fmt.Errorf("receipt assignment count omits an assigned target: %w",
+			ErrInvalidBatchTag)
+	}
+	_, digest, err := validateBatchTagTargets(receipt.TagID, receipt.Assign, targets)
+	if err != nil {
+		return err
+	}
+	if receipt.RequestDigest != digest {
+		return fmt.Errorf("receipt request digest does not match canonical request: %w",
+			ErrInvalidBatchTag)
+	}
+	return nil
+}

--- a/internal/store/batch_tag_metadata.go
+++ b/internal/store/batch_tag_metadata.go
@@ -61,7 +61,7 @@ func validateBatchTagMetadataRecord(record metadataBatchTagReceipt) error {
 	if err := validateUUIDv4(record.OperationID); err != nil {
 		return fmt.Errorf("invalid batch tag receipt operation ID: %w", err)
 	}
-	receipt, err := decodeBatchTagReceipt(record.ReceiptJSON)
+	receipt, err := decodeBatchTagReceiptV1(record.ReceiptJSON)
 	if err != nil {
 		return err
 	}

--- a/internal/store/batch_tag_metadata.go
+++ b/internal/store/batch_tag_metadata.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+const metadataBatchTagReceiptType = "batch_tag_receipt"
+
+type metadataBatchTagReceipt struct {
+	Type          string `json:"type"`
+	OperationID   string `json:"operation_id"`
+	RequestDigest string `json:"request_digest"`
+	ReceiptJSON   []byte `json:"receipt_json" format:"byte"`
+}
+
+func exportBatchTagReceipts(
+	ctx context.Context, tx metadataQuerier, write metadataWrite,
+) error {
+	rows, err := tx.QueryContext(ctx, `SELECT operation_id,request_digest,receipt_json
+		FROM batch_tag_receipts ORDER BY operation_id`)
+	if err != nil {
+		return fmt.Errorf("exporting batch tag receipts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		record := metadataBatchTagReceipt{Type: metadataBatchTagReceiptType}
+		if err := rows.Scan(
+			&record.OperationID, &record.RequestDigest, &record.ReceiptJSON,
+		); err != nil {
+			return fmt.Errorf("scanning batch tag receipt metadata: %w", err)
+		}
+		if err := validateBatchTagMetadataRecord(record); err != nil {
+			return fmt.Errorf("validating batch tag receipt metadata for export: %w", err)
+		}
+		if err := write(record); err != nil {
+			return err
+		}
+	}
+	return rowsError("batch tag receipt", rows)
+}
+
+func importBatchTagReceipt(
+	ctx context.Context, tx *sql.Tx, record metadataBatchTagReceipt,
+) error {
+	if err := validateBatchTagMetadataRecord(record); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `INSERT INTO batch_tag_receipts(
+		operation_id,request_digest,receipt_json) VALUES(?,?,?)`,
+		record.OperationID, record.RequestDigest, record.ReceiptJSON)
+	return err
+}
+
+func validateBatchTagMetadataRecord(record metadataBatchTagReceipt) error {
+	if record.Type != metadataBatchTagReceiptType {
+		return errors.New("invalid batch tag receipt metadata type")
+	}
+	if err := validateUUIDv4(record.OperationID); err != nil {
+		return fmt.Errorf("invalid batch tag receipt operation ID: %w", err)
+	}
+	receipt, err := decodeBatchTagReceipt(record.ReceiptJSON)
+	if err != nil {
+		return err
+	}
+	if receipt.OperationID != record.OperationID || receipt.RequestDigest != record.RequestDigest {
+		return errors.New("batch tag receipt metadata identity does not match receipt JSON")
+	}
+	return nil
+}
+
+func validateBatchTagReceiptMetadataState(ctx context.Context, tx metadataQuerier) error {
+	return exportBatchTagReceipts(ctx, tx, func(any) error { return nil })
+}

--- a/internal/store/batch_tag_metadata_test.go
+++ b/internal/store/batch_tag_metadata_test.go
@@ -11,20 +11,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBatchTagReceiptV1WireFormat(t *testing.T) {
+	// Persisted receipt bytes are immutable and must outlive API response changes.
+	const stored = `{"version":1,"operation_id":"11111111-1111-4111-8111-111111111111","request_digest":"9d29429ce1a103db51351b4d136306a00fb8dc77ae392b506ba09e625073c725","tag_id":"22222222-2222-4222-8222-222222222222","assign":true,"tag_revision":3,"assignment_count":2,"completed_at":"2026-09-11T12:00:00.000000000Z","nodes":[{"node_id":7,"expected_revision":3,"revision":4,"changed":true},{"node_id":9,"expected_revision":4,"revision":5,"changed":true}]}`
+	receipt, err := decodeBatchTagReceiptV1([]byte(stored))
+	require.NoError(t, err)
+	require.Equal(t, validBatchTagReceiptForTest(), receipt)
+}
+
 func TestDecodeBatchTagReceiptRejectsOversizedInput(t *testing.T) {
-	_, err := decodeBatchTagReceipt(bytes.Repeat([]byte{' '}, maxBatchTagReceiptJSONBytes+1))
+	_, err := decodeBatchTagReceiptV1(bytes.Repeat([]byte{' '}, maxBatchTagReceiptJSONBytes+1))
 	require.ErrorIs(t, err, ErrInvalidBatchTag)
 }
 
 func TestBatchTagReceiptRejectsImpossibleFinalTagState(t *testing.T) {
 	for _, test := range []struct {
 		name   string
-		mutate func(*BatchTagReceipt)
+		mutate func(*BatchTagReceiptV1)
 	}{
-		{name: "tag revision does not exceed change count", mutate: func(r *BatchTagReceipt) {
+		{name: "tag revision does not exceed change count", mutate: func(r *BatchTagReceiptV1) {
 			r.TagRevision = 2
 		}},
-		{name: "assign count omits a target", mutate: func(r *BatchTagReceipt) {
+		{name: "assign count omits a target", mutate: func(r *BatchTagReceiptV1) {
 			r.AssignmentCount = 1
 		}},
 	} {
@@ -33,7 +41,7 @@ func TestBatchTagReceiptRejectsImpossibleFinalTagState(t *testing.T) {
 			test.mutate(&receipt)
 			encoded, err := json.Marshal(receipt, json.Deterministic(true))
 			require.NoError(t, err)
-			_, err = decodeBatchTagReceipt(encoded)
+			_, err = decodeBatchTagReceiptV1(encoded)
 			require.ErrorIs(t, err, ErrInvalidBatchTag)
 		})
 	}
@@ -72,7 +80,7 @@ func TestBatchTagReceiptMetadataRejectsTamperingTransactionally(t *testing.T) {
 		record.ReceiptJSON = append(record.ReceiptJSON, '\n')
 	})
 	invalidTransition := mutateBatchTagMetadata(t, exported.Bytes(), func(record *metadataBatchTagReceipt) {
-		var receipt BatchTagReceipt
+		var receipt BatchTagReceiptV1
 		require.NoError(t, json.Unmarshal(record.ReceiptJSON, &receipt))
 		receipt.Nodes[0].Revision++
 		record.ReceiptJSON, err = json.Marshal(receipt, json.Deterministic(true))
@@ -208,14 +216,14 @@ func TestAuditedBatchTagReceiptSurvivesBackupMetadataSnapshot(t *testing.T) {
 	assert.Equal(t, backup.Bytes(), roundTrip.Bytes())
 }
 
-func validBatchTagReceiptForTest() BatchTagReceipt {
-	return BatchTagReceipt{
+func validBatchTagReceiptForTest() BatchTagReceiptV1 {
+	return BatchTagReceiptV1{
 		Version: 1, OperationID: "11111111-1111-4111-8111-111111111111",
 		RequestDigest: "9d29429ce1a103db51351b4d136306a00fb8dc77ae392b506ba09e625073c725",
 		TagID:         "22222222-2222-4222-8222-222222222222", Assign: true,
 		TagRevision: 3, AssignmentCount: 2,
 		CompletedAt: "2026-09-11T12:00:00.000000000Z",
-		Nodes: []BatchTagNodeResult{
+		Nodes: []BatchTagNodeResultV1{
 			{NodeID: 7, ExpectedRevision: 3, Revision: 4, Changed: true},
 			{NodeID: 9, ExpectedRevision: 4, Revision: 5, Changed: true},
 		},

--- a/internal/store/batch_tag_metadata_test.go
+++ b/internal/store/batch_tag_metadata_test.go
@@ -1,0 +1,295 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeBatchTagReceiptRejectsOversizedInput(t *testing.T) {
+	_, err := decodeBatchTagReceipt(bytes.Repeat([]byte{' '}, maxBatchTagReceiptJSONBytes+1))
+	require.ErrorIs(t, err, ErrInvalidBatchTag)
+}
+
+func TestBatchTagReceiptRejectsImpossibleFinalTagState(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*BatchTagReceipt)
+	}{
+		{name: "tag revision does not exceed change count", mutate: func(r *BatchTagReceipt) {
+			r.TagRevision = 2
+		}},
+		{name: "assign count omits a target", mutate: func(r *BatchTagReceipt) {
+			r.AssignmentCount = 1
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			receipt := validBatchTagReceiptForTest()
+			test.mutate(&receipt)
+			encoded, err := json.Marshal(receipt, json.Deterministic(true))
+			require.NoError(t, err)
+			_, err = decodeBatchTagReceipt(encoded)
+			require.ErrorIs(t, err, ErrInvalidBatchTag)
+		})
+	}
+}
+
+func TestBatchTagReceiptMetadataRejectsTamperingTransactionally(t *testing.T) {
+	source := newTestStore(t)
+	node, err := source.Mkdir(t.Context(), source.RootID(), "portable")
+	require.NoError(t, err)
+	tag, err := source.CreateTag(t.Context(), "Portable")
+	require.NoError(t, err)
+	_, err = source.BatchTags(t.Context(), BatchTagRequest{
+		OperationID: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	})
+	require.NoError(t, err)
+	var exported bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &exported))
+	record := batchTagMetadataRecordFromExport(t, exported.Bytes())
+
+	duplicate := appendMetadataRecords(t, exported.Bytes(), record)
+	missingField := mutateBatchTagMetadataLine(t, exported.Bytes(), func(fields map[string]jsontext.Value) {
+		delete(fields, auditOperationIDField)
+	})
+	unknownField := mutateBatchTagMetadataLine(t, exported.Bytes(), func(fields map[string]jsontext.Value) {
+		fields["unexpected"] = jsontext.Value(`true`)
+	})
+	mismatchedOperation := mutateBatchTagMetadata(t, exported.Bytes(), func(record *metadataBatchTagReceipt) {
+		record.OperationID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+	})
+	mismatchedDigest := mutateBatchTagMetadata(t, exported.Bytes(), func(record *metadataBatchTagReceipt) {
+		record.RequestDigest = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	})
+	noncanonicalReceipt := mutateBatchTagMetadata(t, exported.Bytes(), func(record *metadataBatchTagReceipt) {
+		record.ReceiptJSON = append(record.ReceiptJSON, '\n')
+	})
+	invalidTransition := mutateBatchTagMetadata(t, exported.Bytes(), func(record *metadataBatchTagReceipt) {
+		var receipt BatchTagReceipt
+		require.NoError(t, json.Unmarshal(record.ReceiptJSON, &receipt))
+		receipt.Nodes[0].Revision++
+		record.ReceiptJSON, err = json.Marshal(receipt, json.Deterministic(true))
+		require.NoError(t, err)
+	})
+
+	for _, test := range []struct {
+		name  string
+		input []byte
+	}{
+		{name: "duplicate", input: duplicate},
+		{name: "missing field", input: missingField},
+		{name: "unknown field", input: unknownField},
+		{name: "mismatched operation", input: mismatchedOperation},
+		{name: "mismatched digest", input: mismatchedDigest},
+		{name: "noncanonical receipt", input: noncanonicalReceipt},
+		{name: "invalid revision transition", input: invalidTransition},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			target := newTestStore(t)
+			targetVaultID := target.VaultID()
+			err := target.ImportMetadata(t.Context(), bytes.NewReader(test.input))
+			require.Error(t, err)
+			assert.Equal(t, targetVaultID, target.VaultID())
+			var nodes, receipts int
+			require.NoError(t, target.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM nodes),
+				(SELECT COUNT(*) FROM batch_tag_receipts)`).Scan(&nodes, &receipts))
+			assert.Equal(t, 1, nodes)
+			assert.Zero(t, receipts)
+		})
+	}
+}
+
+func TestBatchTagReceiptStateValidationRejectsCorruptStoredBytes(t *testing.T) {
+	s := newTestStore(t)
+	node, err := s.Mkdir(t.Context(), s.RootID(), "corrupt")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(t.Context(), "Corrupt")
+	require.NoError(t, err)
+	receipt, err := s.BatchTags(t.Context(), BatchTagRequest{
+		OperationID: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	})
+	require.NoError(t, err)
+	_, err = s.db.Exec(`DROP TRIGGER batch_tag_receipts_immutable_update`)
+	require.NoError(t, err, "simulate corruption outside the supported Store boundary")
+	_, err = s.db.Exec(`UPDATE batch_tag_receipts SET receipt_json=receipt_json||x'0a'
+		WHERE operation_id=?`, receipt.OperationID)
+	require.NoError(t, err)
+	err = s.ValidateMetadata(t.Context())
+	require.ErrorContains(t, err, "not canonical")
+	_, err = s.BatchTags(t.Context(), BatchTagRequest{
+		OperationID: receipt.OperationID, TagID: tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	})
+	require.ErrorContains(t, err, "not canonical")
+}
+
+func TestBatchTagReceiptRowsAreImmutable(t *testing.T) {
+	s := newTestStore(t)
+	node, err := s.Mkdir(t.Context(), s.RootID(), "immutable")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(t.Context(), "Immutable")
+	require.NoError(t, err)
+	receipt, err := s.BatchTags(t.Context(), BatchTagRequest{
+		OperationID: "13131313-1313-4313-8313-131313131313",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	})
+	require.NoError(t, err)
+	_, err = s.db.Exec(`UPDATE batch_tag_receipts SET request_digest=request_digest
+		WHERE operation_id=?`, receipt.OperationID)
+	require.ErrorContains(t, err, "immutable")
+	_, err = s.db.Exec(`DELETE FROM batch_tag_receipts WHERE operation_id=?`, receipt.OperationID)
+	require.ErrorContains(t, err, "immutable")
+	var rows int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM batch_tag_receipts
+		WHERE operation_id=?`, receipt.OperationID).Scan(&rows))
+	assert.Equal(t, 1, rows)
+}
+
+func TestBatchTagReceiptMakesMetadataTargetNonPristine(t *testing.T) {
+	source := newTestStore(t)
+	var emptyExport bytes.Buffer
+	require.NoError(t, source.ExportMetadata(t.Context(), &emptyExport))
+	target := newTestStore(t)
+	node, err := target.Mkdir(t.Context(), target.RootID(), "existing")
+	require.NoError(t, err)
+	tag, err := target.CreateTag(t.Context(), "Existing")
+	require.NoError(t, err)
+	_, err = target.BatchTags(t.Context(), BatchTagRequest{
+		OperationID: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	})
+	require.NoError(t, err)
+	err = target.ImportMetadata(t.Context(), bytes.NewReader(emptyExport.Bytes()))
+	require.ErrorContains(t, err, "not pristine")
+	var receipts int
+	require.NoError(t, target.db.QueryRow(`SELECT COUNT(*) FROM batch_tag_receipts`).Scan(&receipts))
+	assert.Equal(t, 1, receipts)
+}
+
+func TestAuditedBatchTagReceiptSurvivesBackupMetadataSnapshot(t *testing.T) {
+	source, tag, report := newAuditedTagStore(t)
+	receipt, err := source.BatchTags(t.Context(), BatchTagRequest{
+		OperationID: "12121212-1212-4212-8212-121212121212",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: report.ID, Revision: report.Revision}},
+	})
+	require.NoError(t, err)
+	snapshot, err := source.BeginMetadataSnapshot(t.Context())
+	require.NoError(t, err)
+	var backup bytes.Buffer
+	require.NoError(t, snapshot.ExportBackup(t.Context(), &backup))
+	require.NoError(t, snapshot.Close())
+
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(backup.Bytes())))
+	require.NoError(t, restored.ValidateMetadata(t.Context()))
+	replayed, err := restored.BatchTags(t.Context(), BatchTagRequest{
+		OperationID: receipt.OperationID, TagID: tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: report.ID, Revision: report.Revision}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, receipt, replayed)
+	var roundTrip bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(t.Context(), &roundTrip))
+	assert.Equal(t, backup.Bytes(), roundTrip.Bytes())
+}
+
+func validBatchTagReceiptForTest() BatchTagReceipt {
+	return BatchTagReceipt{
+		Version: 1, OperationID: "11111111-1111-4111-8111-111111111111",
+		RequestDigest: "9d29429ce1a103db51351b4d136306a00fb8dc77ae392b506ba09e625073c725",
+		TagID:         "22222222-2222-4222-8222-222222222222", Assign: true,
+		TagRevision: 3, AssignmentCount: 2,
+		CompletedAt: "2026-09-11T12:00:00.000000000Z",
+		Nodes: []BatchTagNodeResult{
+			{NodeID: 7, ExpectedRevision: 3, Revision: 4, Changed: true},
+			{NodeID: 9, ExpectedRevision: 4, Revision: 5, Changed: true},
+		},
+	}
+}
+
+func batchTagMetadataRecordFromExport(t *testing.T, input []byte) metadataBatchTagReceipt {
+	t.Helper()
+	for line := range bytes.SplitSeq(bytes.TrimSpace(input), []byte{'\n'}) {
+		var kind struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &kind))
+		if kind.Type != metadataBatchTagReceiptType {
+			continue
+		}
+		var record metadataBatchTagReceipt
+		require.NoError(t, json.Unmarshal(line, &record))
+		return record
+	}
+	require.FailNow(t, "batch tag receipt metadata record not found")
+	return metadataBatchTagReceipt{}
+}
+
+func mutateBatchTagMetadata(
+	t *testing.T, input []byte, mutate func(*metadataBatchTagReceipt),
+) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	found := false
+	for i, line := range lines {
+		var kind struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &kind))
+		if kind.Type != metadataBatchTagReceiptType {
+			continue
+		}
+		var record metadataBatchTagReceipt
+		require.NoError(t, json.Unmarshal(line, &record))
+		mutate(&record)
+		var err error
+		lines[i], err = json.Marshal(record, json.Deterministic(true))
+		require.NoError(t, err)
+		found = true
+		break
+	}
+	require.True(t, found)
+	return append(bytes.Join(lines, []byte{'\n'}), '\n')
+}
+
+func mutateBatchTagMetadataLine(
+	t *testing.T, input []byte, mutate func(map[string]jsontext.Value),
+) []byte {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(input), []byte{'\n'})
+	found := false
+	for i, line := range lines {
+		var kind struct {
+			Type string `json:"type"`
+		}
+		require.NoError(t, json.Unmarshal(line, &kind))
+		if kind.Type != metadataBatchTagReceiptType {
+			continue
+		}
+		var fields map[string]jsontext.Value
+		require.NoError(t, json.Unmarshal(line, &fields))
+		mutate(fields)
+		var err error
+		lines[i], err = json.Marshal(fields, json.Deterministic(true))
+		require.NoError(t, err)
+		found = true
+		break
+	}
+	require.True(t, found)
+	return append(bytes.Join(lines, []byte{'\n'}), '\n')
+}

--- a/internal/store/batch_tag_test.go
+++ b/internal/store/batch_tag_test.go
@@ -1,0 +1,617 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchTagsReplayAfterInterveningChange(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	node, err := s.Mkdir(ctx, s.RootID(), "selected")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(ctx, "Review")
+	require.NoError(t, err)
+	request := BatchTagRequest{
+		OperationID: "11111111-1111-4111-8111-111111111111",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	}
+	first, err := s.BatchTags(ctx, request)
+	require.NoError(t, err)
+	require.Len(t, first.Nodes, 1)
+	require.True(t, first.Nodes[0].Changed)
+	_, err = s.UnassignTag(ctx, tag.ID, node.ID, first.Nodes[0].Revision)
+	require.NoError(t, err)
+	replay, err := s.BatchTags(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, first, replay)
+	request.Assign = false
+	_, err = s.BatchTags(ctx, request)
+	require.ErrorIs(t, err, ErrBatchTagOperationConflict)
+
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(ctx, &exported))
+	restored, err := Open(filepath.Join(t.TempDir(), "restored.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, restored.Close()) })
+	require.NoError(t, restored.ImportMetadata(ctx, bytes.NewReader(exported.Bytes())))
+	request.Assign = true
+	restoredReplay, err := restored.BatchTags(ctx, request)
+	require.NoError(t, err)
+	require.Equal(t, first, restoredReplay)
+	var reexported bytes.Buffer
+	require.NoError(t, restored.ExportMetadata(ctx, &reexported))
+	require.Equal(t, exported.Bytes(), reexported.Bytes())
+}
+
+func TestBatchTagDigestGoldenVector(t *testing.T) {
+	targets := []BatchTagTarget{{NodeID: 9, Revision: 4}, {NodeID: 7, Revision: 3}}
+	sorted, digest, err := validateBatchTagTargets(
+		"22222222-2222-4222-8222-222222222222", true, targets,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []BatchTagTarget{{NodeID: 7, Revision: 3}, {NodeID: 9, Revision: 4}}, sorted)
+	assert.Equal(t, "9d29429ce1a103db51351b4d136306a00fb8dc77ae392b506ba09e625073c725", digest)
+	assert.Equal(t, []BatchTagTarget{{NodeID: 9, Revision: 4}, {NodeID: 7, Revision: 3}}, targets,
+		"digest canonicalization must not mutate caller input")
+}
+
+func TestBatchTagsRejectsInvalidStructureWithoutWrites(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	node, err := s.Mkdir(ctx, s.RootID(), "selected")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(ctx, "Bounds")
+	require.NoError(t, err)
+	valid := BatchTagRequest{
+		OperationID: "11111111-1111-4111-8111-111111111111",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	}
+	tooMany := make([]BatchTagTarget, maxBatchTagTargets+1)
+	for i := range tooMany {
+		tooMany[i] = BatchTagTarget{NodeID: int64(i + 1), Revision: 1}
+	}
+	tests := []struct {
+		name   string
+		mutate func(*BatchTagRequest)
+	}{
+		{name: "empty", mutate: func(r *BatchTagRequest) { r.Nodes = nil }},
+		{name: "oversized", mutate: func(r *BatchTagRequest) { r.Nodes = tooMany }},
+		{name: "duplicate", mutate: func(r *BatchTagRequest) { r.Nodes = append(r.Nodes, r.Nodes[0]) }},
+		{name: "invalid operation ID", mutate: func(r *BatchTagRequest) { r.OperationID = "not-a-uuid" }},
+		{name: "invalid tag ID", mutate: func(r *BatchTagRequest) { r.TagID = "not-a-uuid" }},
+		{name: "zero node ID", mutate: func(r *BatchTagRequest) { r.Nodes[0].NodeID = 0 }},
+		{name: "zero revision", mutate: func(r *BatchTagRequest) { r.Nodes[0].Revision = 0 }},
+		{name: "negative revision", mutate: func(r *BatchTagRequest) { r.Nodes[0].Revision = -1 }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := valid
+			request.Nodes = append([]BatchTagTarget(nil), valid.Nodes...)
+			test.mutate(&request)
+			_, err := s.BatchTags(ctx, request)
+			require.ErrorIs(t, err, ErrInvalidBatchTag)
+		})
+	}
+	var receipts, assignments int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM batch_tag_receipts),
+		(SELECT COUNT(*) FROM node_tags)`).Scan(&receipts, &assignments))
+	assert.Zero(t, receipts)
+	assert.Zero(t, assignments)
+	unchanged, err := s.NodeByID(ctx, node.ID)
+	require.NoError(t, err)
+	assert.Equal(t, node.Revision, unchanged.Revision)
+}
+
+func TestBatchTagsMixedChangesNoOpsAndCallerOrder(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	first, err := s.Mkdir(ctx, s.RootID(), "first")
+	require.NoError(t, err)
+	second, err := s.Mkdir(ctx, s.RootID(), "second")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(ctx, "Mixed")
+	require.NoError(t, err)
+	assigned, err := s.AssignTag(ctx, tag.ID, first.ID, first.Revision)
+	require.NoError(t, err)
+	first, tag = assigned.Node, assigned.Tag
+	targets := []BatchTagTarget{
+		{NodeID: second.ID, Revision: second.Revision},
+		{NodeID: first.ID, Revision: first.Revision},
+	}
+	wantTargets := append([]BatchTagTarget(nil), targets...)
+
+	request := BatchTagRequest{
+		OperationID: "22222222-2222-4222-8222-222222222222",
+		TagID:       tag.ID, Assign: true, Nodes: targets,
+	}
+	receipt, err := s.BatchTags(ctx, request)
+	require.NoError(t, err)
+	assert.Equal(t, wantTargets, targets)
+	assert.Equal(t, tag.Revision+1, receipt.TagRevision)
+	assert.Equal(t, 2, receipt.AssignmentCount)
+	assert.Equal(t, []BatchTagNodeResult{
+		{NodeID: first.ID, ExpectedRevision: first.Revision, Revision: first.Revision, Changed: false},
+		{NodeID: second.ID, ExpectedRevision: second.Revision, Revision: second.Revision + 1, Changed: true},
+	}, receipt.Nodes)
+	require.NoError(t, validateMetadataTime("completed_at", receipt.CompletedAt))
+	canonical, err := canonicalBatchTagReceiptJSON(receipt)
+	require.NoError(t, err)
+	var stored []byte
+	require.NoError(t, s.db.QueryRow(`SELECT receipt_json FROM batch_tag_receipts
+		WHERE operation_id=?`, receipt.OperationID).Scan(&stored))
+	assert.Equal(t, canonical, stored)
+	request.Nodes = []BatchTagTarget{
+		{NodeID: first.ID, Revision: first.Revision},
+		{NodeID: second.ID, Revision: second.Revision},
+	}
+	reorderedReplay, err := s.BatchTags(ctx, request)
+	require.NoError(t, err)
+	assert.Equal(t, receipt, reorderedReplay)
+}
+
+func TestBatchTagsAcceptsOneAndOneThousandTargets(t *testing.T) {
+	for _, count := range []int{1, maxBatchTagTargets} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			s := newTestStore(t)
+			nodes := createBatchTagDirectories(t, s, count)
+			tag, err := s.CreateTag(t.Context(), "Bounded")
+			require.NoError(t, err)
+			targets := make([]BatchTagTarget, len(nodes))
+			for i := range nodes {
+				targets[len(nodes)-1-i] = BatchTagTarget{NodeID: nodes[i].ID, Revision: nodes[i].Revision}
+			}
+			receipt, err := s.BatchTags(t.Context(), BatchTagRequest{
+				OperationID: fmt.Sprintf("33333333-3333-4333-8333-%012d", count),
+				TagID:       tag.ID, Assign: true, Nodes: targets,
+			})
+			require.NoError(t, err)
+			require.Len(t, receipt.Nodes, count)
+			assert.Equal(t, count, receipt.AssignmentCount)
+			assert.Equal(t, tag.Revision+int64(count), receipt.TagRevision)
+			for i, result := range receipt.Nodes {
+				assert.Equal(t, nodes[i].ID, result.NodeID)
+				assert.True(t, result.Changed)
+				assert.Equal(t, nodes[i].Revision+1, result.Revision)
+			}
+		})
+	}
+}
+
+func TestBatchTagsRejectsLateInvalidTargetAtomically(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		prepare func(*testing.T, *Store, Node) BatchTagTarget
+	}{
+		{name: "stale", prepare: func(_ *testing.T, _ *Store, node Node) BatchTagTarget {
+			return BatchTagTarget{NodeID: node.ID, Revision: node.Revision + 1}
+		}},
+		{name: "missing", prepare: func(_ *testing.T, _ *Store, node Node) BatchTagTarget {
+			return BatchTagTarget{NodeID: node.ID + 10000, Revision: node.Revision}
+		}},
+		{name: "trashed", prepare: func(t *testing.T, s *Store, node Node) BatchTagTarget {
+			t.Helper()
+			trashed, _, err := s.Trash(t.Context(), node.ID, node.Revision)
+			require.NoError(t, err)
+			return BatchTagTarget{NodeID: trashed.ID, Revision: trashed.Revision}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := newTestStore(t)
+			first, err := s.Mkdir(t.Context(), s.RootID(), "first")
+			require.NoError(t, err)
+			last, err := s.Mkdir(t.Context(), s.RootID(), "last")
+			require.NoError(t, err)
+			tag, err := s.CreateTag(t.Context(), "Atomic")
+			require.NoError(t, err)
+			lastTarget := test.prepare(t, s, last)
+			_, err = s.BatchTags(t.Context(), BatchTagRequest{
+				OperationID: "44444444-4444-4444-8444-444444444444",
+				TagID:       tag.ID, Assign: true,
+				Nodes: []BatchTagTarget{
+					{NodeID: first.ID, Revision: first.Revision}, lastTarget,
+				},
+			})
+			if test.name == "stale" {
+				require.ErrorIs(t, err, ErrStaleRevision)
+			} else {
+				require.ErrorIs(t, err, ErrNotFound)
+			}
+			unchanged, readErr := s.NodeByID(t.Context(), first.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, first.Revision, unchanged.Revision)
+			currentTag, readErr := s.TagByID(t.Context(), tag.ID)
+			require.NoError(t, readErr)
+			assert.Equal(t, tag, currentTag)
+			var receipts, assignments int
+			require.NoError(t, s.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM batch_tag_receipts),
+				(SELECT COUNT(*) FROM node_tags WHERE node_id=?)`, first.ID,
+			).Scan(&receipts, &assignments))
+			assert.Zero(t, receipts)
+			assert.Zero(t, assignments)
+		})
+	}
+}
+
+func TestBatchTagsRejectsRevisionOverflowBeforeWrites(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		update string
+	}{
+		{name: "node", update: `UPDATE nodes SET revision=? WHERE id=?`},
+		{name: "tag", update: `UPDATE tags SET revision=? WHERE id=?`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := newTestStore(t)
+			node, err := s.Mkdir(t.Context(), s.RootID(), "overflow")
+			require.NoError(t, err)
+			tag, err := s.CreateTag(t.Context(), "Overflow")
+			require.NoError(t, err)
+			id := any(node.ID)
+			if test.name == "tag" {
+				id = tag.ID
+			}
+			_, err = s.db.Exec(test.update, int64(math.MaxInt64), id)
+			require.NoError(t, err)
+			if test.name == "node" {
+				node.Revision = math.MaxInt64
+			}
+			_, err = s.BatchTags(t.Context(), BatchTagRequest{
+				OperationID: "55555555-5555-4555-8555-555555555555",
+				TagID:       tag.ID, Assign: true,
+				Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+			})
+			require.ErrorIs(t, err, ErrInvalidBatchTag)
+			var receipts, assignments int
+			require.NoError(t, s.db.QueryRow(`SELECT
+				(SELECT COUNT(*) FROM batch_tag_receipts),
+				(SELECT COUNT(*) FROM node_tags)`).Scan(&receipts, &assignments))
+			assert.Zero(t, receipts)
+			assert.Zero(t, assignments)
+		})
+	}
+}
+
+func TestBatchTagsConcurrentSameOperationReturnsOneReceipt(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "vault.db")
+	firstStore, err := Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, firstStore.Close()) })
+	secondStore, err := Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, secondStore.Close()) })
+	node, err := firstStore.Mkdir(t.Context(), firstStore.RootID(), "concurrent")
+	require.NoError(t, err)
+	tag, err := firstStore.CreateTag(t.Context(), "Concurrent")
+	require.NoError(t, err)
+	request := BatchTagRequest{
+		OperationID: "66666666-6666-4666-8666-666666666666",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	}
+	stores := []*Store{firstStore, secondStore}
+	receipts := make([]BatchTagReceipt, len(stores))
+	errs := make([]error, len(stores))
+	var wg sync.WaitGroup
+	for i := range stores {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			receipts[i], errs[i] = stores[i].BatchTags(context.Background(), request)
+		}(i)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, receipts[0], receipts[1])
+	var receiptRows, assignments int
+	require.NoError(t, firstStore.db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM batch_tag_receipts),
+		(SELECT COUNT(*) FROM node_tags)`).Scan(&receiptRows, &assignments))
+	assert.Equal(t, 1, receiptRows)
+	assert.Equal(t, 1, assignments)
+}
+
+func TestBatchTagsReplaysAfterRestartDeletionAndNodePurge(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "vault.db")
+	s, err := Open(dbPath)
+	require.NoError(t, err)
+	node, err := s.Mkdir(t.Context(), s.RootID(), "historical")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(t.Context(), "Historical")
+	require.NoError(t, err)
+	request := BatchTagRequest{
+		OperationID: "77777777-7777-4777-8777-777777777777",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	}
+	receipt, err := s.BatchTags(t.Context(), request)
+	require.NoError(t, err)
+	require.NoError(t, s.Close())
+
+	s, err = Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	restarted, err := s.BatchTags(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, receipt, restarted)
+	unassigned, err := s.UnassignTag(t.Context(), tag.ID, node.ID, receipt.Nodes[0].Revision)
+	require.NoError(t, err)
+	_, err = s.DeleteTag(t.Context(), tag.ID, unassigned.Tag.Revision)
+	require.NoError(t, err)
+	trashed, _, err := s.Trash(t.Context(), node.ID, unassigned.Node.Revision)
+	require.NoError(t, err)
+	assert.Equal(t, node.ID, trashed.ID)
+	empty, err := s.TrashEmpty(t.Context(), 0, true)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), empty.Deleted)
+	_, err = s.NodeByID(t.Context(), node.ID)
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.TagByID(t.Context(), tag.ID)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	historical, err := s.BatchTags(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, receipt, historical)
+	request.Assign = false
+	_, err = s.BatchTags(t.Context(), request)
+	require.ErrorIs(t, err, ErrBatchTagOperationConflict)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+	var exported bytes.Buffer
+	require.NoError(t, s.ExportMetadata(t.Context(), &exported))
+	restored := newTestStore(t)
+	require.NoError(t, restored.ImportMetadata(t.Context(), bytes.NewReader(exported.Bytes())))
+	request.Assign = true
+	restoredHistorical, err := restored.BatchTags(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, receipt, restoredHistorical)
+}
+
+func TestBatchTagsPropagatesCanceledContextAndBackendErrors(t *testing.T) {
+	s := newTestStore(t)
+	node, err := s.Mkdir(t.Context(), s.RootID(), "cancel")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(t.Context(), "Cancel")
+	require.NoError(t, err)
+	request := BatchTagRequest{
+		OperationID: "88888888-8888-4888-8888-888888888888",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = s.BatchTags(ctx, request)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = s.PreviewBatchTags(ctx, tag.ID, request.Nodes)
+	require.ErrorIs(t, err, context.Canceled)
+
+	closed, err := Open(filepath.Join(t.TempDir(), "closed.db"))
+	require.NoError(t, err)
+	closedNode, err := closed.Mkdir(t.Context(), closed.RootID(), "closed")
+	require.NoError(t, err)
+	closedTag, err := closed.CreateTag(t.Context(), "Closed")
+	require.NoError(t, err)
+	require.NoError(t, closed.Close())
+	closedRequest := BatchTagRequest{
+		OperationID: "99999999-9999-4999-8999-999999999999",
+		TagID:       closedTag.ID, Assign: true,
+		Nodes: []BatchTagTarget{{NodeID: closedNode.ID, Revision: closedNode.Revision}},
+	}
+	_, err = closed.BatchTags(t.Context(), closedRequest)
+	require.Error(t, err)
+	_, err = closed.PreviewBatchTags(t.Context(), closedTag.ID, closedRequest.Nodes)
+	require.Error(t, err)
+}
+
+func TestAuditedBatchTagsCommitAndReplayCanonicalHistory(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	projects, err := s.NodeByPath(t.Context(), "/Projects")
+	require.NoError(t, err)
+	request := BatchTagRequest{
+		OperationID: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{
+			{NodeID: report.ID, Revision: report.Revision},
+			{NodeID: projects.ID, Revision: projects.Revision},
+		},
+	}
+	receipt, err := s.BatchTags(t.Context(), request)
+	require.NoError(t, err)
+	require.Len(t, receipt.Nodes, 2)
+	assert.True(t, receipt.Nodes[0].Changed)
+	assert.True(t, receipt.Nodes[1].Changed)
+	assert.Equal(t, "tag_assign", auditEventKindForSequence(t, s, 3))
+	var before int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`).Scan(&before))
+	assert.Equal(t, int64(3), before)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+
+	replayed, err := s.BatchTags(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, receipt, replayed)
+	var after int64
+	require.NoError(t, s.db.QueryRow(
+		`SELECT operation_sequence_high_water FROM audit_authority`).Scan(&after))
+	assert.Equal(t, before, after)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func TestAuditedBatchTagsRollsBackEarlierTargetWhenLaterTargetIsUnsupported(t *testing.T) {
+	s, tag, report := newAuditedTagStore(t)
+	empty, err := s.NodeByPath(t.Context(), "/Empty")
+	require.NoError(t, err)
+	_, err = s.BatchTags(t.Context(), BatchTagRequest{
+		OperationID: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+		TagID:       tag.ID, Assign: true,
+		Nodes: []BatchTagTarget{
+			{NodeID: report.ID, Revision: report.Revision},
+			{NodeID: empty.ID, Revision: empty.Revision},
+		},
+	})
+	require.ErrorIs(t, err, ErrAuditMutationUnsupported)
+	currentReport, err := s.NodeByID(t.Context(), report.ID)
+	require.NoError(t, err)
+	assert.Equal(t, report.Revision, currentReport.Revision)
+	currentTag, err := s.TagByID(t.Context(), tag.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tag, currentTag)
+	var sequence, receipts, assignments int
+	require.NoError(t, s.db.QueryRow(`SELECT
+		(SELECT operation_sequence_high_water FROM audit_authority),
+		(SELECT COUNT(*) FROM batch_tag_receipts),
+		(SELECT COUNT(*) FROM node_tags WHERE tag_id=?)`, tag.ID,
+	).Scan(&sequence, &receipts, &assignments))
+	assert.Equal(t, 1, sequence)
+	assert.Zero(t, receipts)
+	assert.Zero(t, assignments)
+	require.NoError(t, s.ValidateMetadata(t.Context()))
+}
+
+func createBatchTagDirectories(t *testing.T, s *Store, count int) []Node {
+	t.Helper()
+	result := make([]Node, 0, count)
+	recordedAt := time.Date(2026, time.September, 11, 12, 0, 0, 0, time.UTC).Format(timestampLayout)
+	require.NoError(t, s.withStorageTx(t.Context(), func(tx *sql.Tx) error {
+		for i := range count {
+			row, err := tx.ExecContext(t.Context(), `INSERT INTO nodes(
+				parent_id,name,kind,created_at,modified_at) VALUES(?,?,'dir',?,?)`,
+				s.RootID(), fmt.Sprintf("node-%04d", i), recordedAt, recordedAt)
+			if err != nil {
+				return err
+			}
+			id, err := row.LastInsertId()
+			if err != nil {
+				return err
+			}
+			node, err := nodeByIDTx(tx, id)
+			if err != nil {
+				return err
+			}
+			result = append(result, node)
+		}
+		return nil
+	}))
+	return result
+}
+
+func TestPreviewBatchTagsExactMembershipAndStaleFences(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	first, err := s.Mkdir(ctx, s.RootID(), "first")
+	require.NoError(t, err)
+	second, err := s.Mkdir(ctx, s.RootID(), "second")
+	require.NoError(t, err)
+	third, err := s.Mkdir(ctx, s.RootID(), "third")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(ctx, "Preview")
+	require.NoError(t, err)
+	assigned, err := s.AssignTag(ctx, tag.ID, second.ID, second.Revision)
+	require.NoError(t, err)
+	second = assigned.Node
+	tag = assigned.Tag
+	targets := []BatchTagTarget{
+		{NodeID: third.ID, Revision: third.Revision},
+		{NodeID: first.ID, Revision: first.Revision},
+		{NodeID: second.ID, Revision: second.Revision},
+	}
+	wantTargets := append([]BatchTagTarget(nil), targets...)
+
+	preview, err := s.PreviewBatchTags(ctx, tag.ID, targets)
+	require.NoError(t, err)
+	assert.Equal(t, wantTargets, targets)
+	assert.Equal(t, BatchTagPreview{
+		TagID: tag.ID, TagRevision: tag.Revision,
+		Nodes: []BatchTagPreviewNode{
+			{NodeID: first.ID, Revision: first.Revision, Assigned: false},
+			{NodeID: second.ID, Revision: second.Revision, Assigned: true},
+			{NodeID: third.ID, Revision: third.Revision, Assigned: false},
+		},
+	}, preview)
+	var receipts int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM batch_tag_receipts`).Scan(&receipts))
+	assert.Zero(t, receipts)
+
+	targets[2].Revision--
+	stale, err := s.PreviewBatchTags(ctx, tag.ID, targets)
+	require.ErrorIs(t, err, ErrStaleRevision)
+	assert.Zero(t, stale)
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM batch_tag_receipts`).Scan(&receipts))
+	assert.Zero(t, receipts)
+}
+
+func TestPreviewBatchTagsAllNoneAndInvalidTargets(t *testing.T) {
+	s := newTestStore(t)
+	ctx := t.Context()
+	first, err := s.Mkdir(ctx, s.RootID(), "first")
+	require.NoError(t, err)
+	second, err := s.Mkdir(ctx, s.RootID(), "second")
+	require.NoError(t, err)
+	tag, err := s.CreateTag(ctx, "Tri-state")
+	require.NoError(t, err)
+	targets := []BatchTagTarget{
+		{NodeID: second.ID, Revision: second.Revision},
+		{NodeID: first.ID, Revision: first.Revision},
+	}
+	none, err := s.PreviewBatchTags(ctx, tag.ID, targets)
+	require.NoError(t, err)
+	for _, node := range none.Nodes {
+		assert.False(t, node.Assigned)
+	}
+	firstAssigned, err := s.AssignTag(ctx, tag.ID, first.ID, first.Revision)
+	require.NoError(t, err)
+	secondAssigned, err := s.AssignTag(ctx, tag.ID, second.ID, second.Revision)
+	require.NoError(t, err)
+	targets = []BatchTagTarget{
+		{NodeID: first.ID, Revision: firstAssigned.Node.Revision},
+		{NodeID: second.ID, Revision: secondAssigned.Node.Revision},
+	}
+	all, err := s.PreviewBatchTags(ctx, tag.ID, targets)
+	require.NoError(t, err)
+	for _, node := range all.Nodes {
+		assert.True(t, node.Assigned)
+	}
+	var receipts int
+	require.NoError(t, s.db.QueryRow(`SELECT COUNT(*) FROM batch_tag_receipts`).Scan(&receipts))
+	assert.Zero(t, receipts)
+
+	for name, invalid := range map[string][]BatchTagTarget{
+		"empty":         nil,
+		"duplicate":     {targets[0], targets[0]},
+		"zero node ID":  {{NodeID: 0, Revision: 1}},
+		"zero revision": {{NodeID: first.ID, Revision: 0}},
+		"missing":       {{NodeID: second.ID + 10000, Revision: 1}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := s.PreviewBatchTags(ctx, tag.ID, invalid)
+			if name == "missing" {
+				require.ErrorIs(t, err, ErrNotFound)
+			} else {
+				require.ErrorIs(t, err, ErrInvalidBatchTag)
+			}
+		})
+	}
+	_, err = s.PreviewBatchTags(ctx, "not-a-uuid", targets)
+	require.ErrorIs(t, err, ErrInvalidBatchTag)
+	trashed, _, err := s.Trash(ctx, second.ID, secondAssigned.Node.Revision)
+	require.NoError(t, err)
+	_, err = s.PreviewBatchTags(ctx, tag.ID,
+		[]BatchTagTarget{{NodeID: trashed.ID, Revision: trashed.Revision}})
+	require.ErrorIs(t, err, ErrNotFound)
+}

--- a/internal/store/batch_tag_test.go
+++ b/internal/store/batch_tag_test.go
@@ -144,12 +144,12 @@ func TestBatchTagsMixedChangesNoOpsAndCallerOrder(t *testing.T) {
 	assert.Equal(t, wantTargets, targets)
 	assert.Equal(t, tag.Revision+1, receipt.TagRevision)
 	assert.Equal(t, 2, receipt.AssignmentCount)
-	assert.Equal(t, []BatchTagNodeResult{
+	assert.Equal(t, []BatchTagNodeResultV1{
 		{NodeID: first.ID, ExpectedRevision: first.Revision, Revision: first.Revision, Changed: false},
 		{NodeID: second.ID, ExpectedRevision: second.Revision, Revision: second.Revision + 1, Changed: true},
 	}, receipt.Nodes)
 	require.NoError(t, validateMetadataTime("completed_at", receipt.CompletedAt))
-	canonical, err := canonicalBatchTagReceiptJSON(receipt)
+	canonical, err := canonicalBatchTagReceiptV1JSON(receipt)
 	require.NoError(t, err)
 	var stored []byte
 	require.NoError(t, s.db.QueryRow(`SELECT receipt_json FROM batch_tag_receipts
@@ -187,7 +187,16 @@ func TestBatchTagsAcceptsOneAndOneThousandTargets(t *testing.T) {
 				assert.Equal(t, nodes[i].ID, result.NodeID)
 				assert.True(t, result.Changed)
 				assert.Equal(t, nodes[i].Revision+1, result.Revision)
+				targets[i] = BatchTagTarget{NodeID: result.NodeID, Revision: result.Revision}
 			}
+			removed, err := s.BatchTags(t.Context(), BatchTagRequest{
+				OperationID: fmt.Sprintf("34343434-3434-4343-8343-%012d", count),
+				TagID:       tag.ID, Assign: false, Nodes: targets,
+			})
+			require.NoError(t, err)
+			assert.Zero(t, removed.AssignmentCount)
+			assert.Equal(t, tag.Revision+2*int64(count), removed.TagRevision)
+			require.NoError(t, s.ValidateMetadata(t.Context()))
 		})
 	}
 }
@@ -305,7 +314,7 @@ func TestBatchTagsConcurrentSameOperationReturnsOneReceipt(t *testing.T) {
 		Nodes: []BatchTagTarget{{NodeID: node.ID, Revision: node.Revision}},
 	}
 	stores := []*Store{firstStore, secondStore}
-	receipts := make([]BatchTagReceipt, len(stores))
+	receipts := make([]BatchTagReceiptV1, len(stores))
 	errs := make([]error, len(stores))
 	var wg sync.WaitGroup
 	for i := range stores {

--- a/internal/store/metadata.go
+++ b/internal/store/metadata.go
@@ -334,6 +334,10 @@ func (layout metadataSourceLayout) hasCollectionLabels() bool {
 	return layout.schemaVersion >= 8
 }
 
+func (layout metadataSourceLayout) hasBatchTagReceipts() bool {
+	return layout.schemaVersion >= 9
+}
+
 func exportMetadataSnapshot(ctx context.Context, tx metadataQuerier, w io.Writer) error {
 	return exportMetadataSnapshotWithVaultIdentity(ctx, tx, w, currentMetadataLayout())
 }
@@ -423,6 +427,11 @@ func exportMetadataSnapshotWithVaultIdentity(
 	}
 	if err := exportNodeTags(ctx, tx, write); err != nil {
 		return err
+	}
+	if layout.hasBatchTagReceipts() {
+		if err := exportBatchTagReceipts(ctx, tx, write); err != nil {
+			return err
+		}
 	}
 	if err := exportExtractedText(ctx, tx, write, backupScoped); err != nil {
 		return err
@@ -981,6 +990,7 @@ func requirePristineMetadataTarget(ctx context.Context, tx *sql.Tx) error {
 		    + (SELECT COUNT(*) FROM collection_labels)
 		    + (SELECT COUNT(*) FROM watch_sources)
 		    + (SELECT COUNT(*) FROM tags) + (SELECT COUNT(*) FROM node_tags)
+		    + (SELECT COUNT(*) FROM batch_tag_receipts)
 		    + (SELECT COUNT(*) FROM extracted_text)
 		    + (SELECT COUNT(*) FROM text_extraction_queue)
 		    + (SELECT COUNT(*) FROM text_searchable_versions)
@@ -1322,6 +1332,12 @@ func (s *Store) importMetadataRecord(
 		}
 		_, err := tx.ExecContext(ctx, `INSERT INTO node_tags(node_id,tag_id) VALUES(?,?)`, v.NodeID, v.TagID)
 		return err
+	case metadataBatchTagReceiptType:
+		var v metadataBatchTagReceipt
+		if err := decodeMetadataRecord(raw, &v); err != nil {
+			return err
+		}
+		return importBatchTagReceipt(ctx, tx, v)
 	case "extracted_text":
 		var v metadataExtractedText
 		if err := decodeMetadataRecord(raw, &v); err != nil {
@@ -1418,6 +1434,7 @@ var metadataRequiredFields = map[string][]string{
 	"tag":                                  {metadataTypeField, "tag_id", "name", "revision"},
 	metadataSavedQueryType:                 {metadataTypeField, "saved_query_id", "name", "description", "kind", "payload", "fingerprint", "revision", metadataCreatedAtField, "updated_at"},
 	"node_tag":                             {metadataTypeField, metadataNodeIDField, "tag_id"},
+	metadataBatchTagReceiptType:            {metadataTypeField, auditOperationIDField, "request_digest", "receipt_json"},
 	"extracted_text":                       {metadataTypeField, columnBlobHash, "extractor", "extractor_version", "status", "error", "attempts", "text", "extracted_at"},
 	metadataAuditAuthorityType:             {metadataTypeField, "lineage_id", "operation_sequence_high_water", "allocation_genesis_digest", "allocation_entry_count", "allocation_head"},
 	metadataAuditScopeType:                 {metadataTypeField, auditScopeIDField, "target_node_id", "enable_operation_id", "entry_count", "chain_head"},
@@ -1818,6 +1835,11 @@ func validateMetadataStateWithVaultIdentity(
 	}
 	if layout.hasCollectionLabels() {
 		if err := validateCollectionLabelMetadataState(ctx, tx); err != nil {
+			return err
+		}
+	}
+	if layout.hasBatchTagReceipts() {
+		if err := validateBatchTagReceiptMetadataState(ctx, tx); err != nil {
 			return err
 		}
 	}

--- a/internal/store/schema.sql
+++ b/internal/store/schema.sql
@@ -1183,6 +1183,24 @@ CREATE TABLE IF NOT EXISTS node_tags (
 
 CREATE INDEX IF NOT EXISTS node_tags_tag ON node_tags(tag_id);
 
+-- Immutable protocol replay authority deliberately has no tag or node foreign
+-- keys: a committed operation identity survives later deletion and purge.
+CREATE TABLE IF NOT EXISTS batch_tag_receipts (
+    operation_id  TEXT PRIMARY KEY,
+    request_digest TEXT NOT NULL,
+    receipt_json  BLOB NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS batch_tag_receipts_immutable_update
+BEFORE UPDATE ON batch_tag_receipts BEGIN
+    SELECT RAISE(ABORT, 'batch tag receipts are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS batch_tag_receipts_immutable_delete
+BEFORE DELETE ON batch_tag_receipts BEGIN
+    SELECT RAISE(ABORT, 'batch tag receipts are immutable');
+END;
+
 -- Saved definitions are mutable intent, fenced by revision. Their canonical
 -- payload and fingerprint are validated in Go before they enter authority.
 CREATE TABLE IF NOT EXISTS saved_queries (

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,7 +31,7 @@ type Store struct {
 // by this binary. It is intentionally independent of metadata JSONL's logical
 // format version: physical schema changes can rebuild through the same logical
 // format without changing that portable contract.
-const currentStorageSchemaVersion = 8
+const currentStorageSchemaVersion = 9
 
 // DefaultSQLiteDriver returns the build's standalone-compatible adapter: CGO
 // builds use mattn/go-sqlite3 and no-CGO builds use modernc.org/sqlite.

--- a/internal/store/upgrade.go
+++ b/internal/store/upgrade.go
@@ -73,7 +73,7 @@ var (
 
 var currentSchemaTables = [...]string{
 	"blobs", "blob_packs", "vault_metadata", "blob_stores", "blob_locations", "blob_pack_entries",
-	"saved_queries", "collection_labels",
+	"saved_queries", "collection_labels", "batch_tag_receipts",
 	"vector_index_generations", "vector_index_heads", "vector_index_build_jobs",
 	"vector_index_reader_leases", "vector_index_unavailable_coverage",
 }
@@ -239,7 +239,7 @@ func validateCurrentSchemaColumns(
 	}
 	for _, table := range []string{
 		"blob_stores", "blob_locations", "blob_pack_entries",
-		"saved_queries", "collection_labels",
+		"saved_queries", "collection_labels", "batch_tag_receipts",
 		"vector_index_generations", "vector_index_heads", "vector_index_build_jobs",
 		"vector_index_reader_leases", "vector_index_unavailable_coverage",
 	} {

--- a/internal/store/upgrade_test.go
+++ b/internal/store/upgrade_test.go
@@ -210,6 +210,27 @@ func TestFreshStoresRecordCurrentStorageSchemaVersion(t *testing.T) {
 	}
 }
 
+func TestOpenRejectsUnreleasedSchemaEightWithoutCutover(t *testing.T) {
+	for _, test := range v090UpgradeDrivers() {
+		t.Run(test.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "docbank.db")
+			s, err := Open(dbPath, test.driver)
+			require.NoError(t, err)
+			_, err = s.db.Exec(`DROP TABLE batch_tag_receipts`)
+			require.NoError(t, err)
+			_, err = s.db.Exec(`UPDATE vault_metadata SET schema_version=8 WHERE singleton=1`)
+			require.NoError(t, err)
+			require.NoError(t, s.Close())
+
+			reopened, err := Open(dbPath, test.driver)
+			if reopened != nil {
+				require.NoError(t, reopened.Close())
+			}
+			require.ErrorContains(t, err, "schema version 8 has no supported JSONL cutover")
+		})
+	}
+}
+
 func TestOpenAcceptsCurrentSchemaColumnAddedToEmbeddedSchema(t *testing.T) {
 	originalSchema := schemaSQL
 	t.Cleanup(func() { schemaSQL = originalSchema })


### PR DESCRIPTION
Add or remove a tag from selected documents in one operation. Select files on the displayed page and choose **Edit tags**; the dialog shows whether all, some, or none already have the chosen tag.

Each operation covers an explicit set of at most 1,000 documents. Every displayed revision must still match: either the whole set succeeds or nothing changes. Folders and undisplayed search results are never swept into the operation. Stale or deleted selections require a refresh; audit restrictions and operation-ID collisions retain their own errors.

If the response is lost, **Retry same operation** reuses the original request and returns its retained receipt without applying the change twice. Receipts use a fixed v1 format and survive restart, metadata export/import, and backup/restore. The database reads the selected targets together and applies bulk writes. Permanent audit records remain per document, with separate audit operation IDs and a shared batch timestamp.

![Selected-document tagging with a mixed tag assignment on synthetic documents](https://raw.githubusercontent.com/salmonumbrella/docbank/25644752679d748d26dd46c481dd8e5cdec252bf/web-batch-tags.png)
