### PR TITLE
Edit and validate complete search queries

### DIFF
--- a/docs/usage/searching.md
+++ b/docs/usage/searching.md
@@ -216,6 +216,16 @@ in a vault that needs editable saved definitions.
 
 ## Preview a field-aware query
 
+In the web application, choose **Edit query** for expression editing, structured
+facet summaries, syntax help, and positioned server errors. A saved query can
+open in the same editor; an import collection can start a new collection-scoped
+draft. Text, facets, mode, and sort remain together when saved or kept in the
+URL. Closing the editor does not discard the draft.
+
+The editor validates intent only. It never sends an unsupported query through
+ordinary live search with constraints removed. **Run query** is unavailable
+until a route can honor the full query contract.
+
 `POST /api/v1/queries/parse` validates a QueryV1 expression and resolves its
 references. It returns `query`, `query_fingerprint`, and `dependencies`, each
 with a `kind`, stable `id`, and observed `revision`. It does not return search

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -115,6 +115,29 @@ It does not download document contents, fetch additional metadata, or include
 results beyond the loaded page. Formula-leading text is escaped for spreadsheet
 imports, and international filenames are preserved.
 
+## Edit a complete query
+
+Choose **Edit query** to write a complete expression, select simple or advanced
+syntax, and edit its mode, sort, and structured facets. Facets stay separate
+from field operands in the expression. Their summaries show the constraints
+you entered; validation does not move operands into hidden filters.
+
+The daemon validates each edited draft after a short pause. It resolves saved,
+tag, and collection references and reports their observed revisions. Errors
+remain visible; **Focus query error** selects the reported part of the
+expression. A newer edit cancels and supersedes an older validation request.
+
+**Save query draft** opens the saved-definition editor with the entire draft.
+**Open query** beside a saved query opens it here. From an import collection,
+**New query for this collection** starts a new draft scoped to that collection's
+stable identity. Closing the query editor keeps the draft in the tab and URL;
+**Discard query draft** removes it.
+
+Validation does not execute a search. **Run query** remains unavailable because
+the live-search endpoint cannot honor the complete expression, facets, and
+ordering contract. Ordinary name/content search remains separate and does not
+inherit draft constraints. See [field-aware query syntax](searching.md#preview-a-field-aware-query).
+
 ## Assign and remove tags
 
 1. Select a file or folder.
@@ -562,7 +585,9 @@ accepts that credential for the following operations:
 | Read collections and their members | Returns bounded lists of live import membership. |
 | Set or clear a collection label | Requires the inspected collection-label revision. |
 
-Use the bookmark button to [manage saved queries and highlights](#saved-queries-and-highlights).
+Use the bookmark button to [manage saved queries and highlights](#saved-queries-and-highlights)
+or **Edit query** to [validate a complete query draft](#edit-a-complete-query).
+Validation does not execute a query.
 
 Upload uses a separate WebSocket: a connection that never reconnects during the
 session. The browser must prove it holds the upload secret before sending any

--- a/docs/usage/web.md
+++ b/docs/usage/web.md
@@ -133,6 +133,10 @@ expression. A newer edit cancels and supersedes an older validation request.
 stable identity. Closing the query editor keeps the draft in the tab and URL;
 **Discard query draft** removes it.
 
+If the draft has malformed input, such as incomplete facets JSON, correct it
+or choose **Discard query draft** before closing. The editor stays open so
+those unfinished edits are not lost.
+
 Validation does not execute a search. **Run query** remains unavailable because
 the live-search endpoint cannot honor the complete expression, facets, and
 ordering contract. Ordinary name/content search remains separate and does not

--- a/frontend/screenshots/query-bar.screenshot.ts
+++ b/frontend/screenshots/query-bar.screenshot.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const exec = promisify(execFile);
+const repository = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const screenshots = process.env.DOCBANK_QUERY_BAR_SCREENSHOT_DIR;
+test.skip(!screenshots, "DOCBANK_QUERY_BAR_SCREENSHOT_DIR is required for PR-only query-bar captures");
+test("complete query validation uses the real compiler without executing", async ({page}) => {
+  const workspace = await mkdtemp(path.join(tmpdir(),"docbank-query-bar-"));
+  const run = async (...args:string[]) => (await exec(path.join(repository,"docbank"),args,{
+    cwd:repository,env:{...process.env,DOCBANK_HOME:path.join(workspace,"vault")},timeout:60_000,
+  })).stdout.trim();
+  try {
+    await writeFile(path.join(workspace,"manual.txt"),"Synthetic field manual and archive notes.\n",{mode:0o600});
+    await run("add",path.join(workspace,"manual.txt"),"--dest","/");
+    await page.goto(await run("web","--no-browser"));
+    await page.getByRole("button",{name:"Import collections",exact:true}).click();
+    const collections=page.getByRole("dialog",{name:"Import collections"});
+    await collections.getByRole("button",{name:/Browse collection/}).first().click();
+    await collections.getByRole("button",{name:"New query for this collection"}).click();
+    const editor=page.getByRole("region",{name:"Query editor"});
+    await expect(editor.getByText(/Query validated/)).toBeVisible();
+    const initial=JSON.parse(new URLSearchParams(new URL(page.url()).hash.slice(1)).get("query")!);
+    expect(initial.filters.collection_ids).toHaveLength(1);
+    const searches:string[]=[];
+    page.on("request",(request)=>{if(new URL(request.url()).pathname==="/api/v1/search") searches.push(request.url());});
+    await editor.getByRole("combobox",{name:"Query syntax: Simple"}).click();
+    await page.getByRole("option",{name:"Advanced",exact:true}).click();
+    await editor.getByLabel("Query expression",{exact:true}).fill("name:manual OR archive");
+    await expect(editor.getByText(/Query validated/)).toBeVisible();
+    await mkdir(screenshots!,{recursive:true,mode:0o700});
+    await page.screenshot({path:path.join(screenshots!,"web-query-bar.png"),fullPage:true});
+    await editor.getByLabel("Query expression",{exact:true}).fill("NOT tag:missing-tag");
+    await expect(editor.getByRole("alert")).toBeVisible();
+    await expect(editor.getByRole("button",{name:"Run query"})).toBeDisabled();
+    await editor.getByRole("button",{name:"Focus query error"}).click();
+    await expect(editor.getByLabel("Query expression",{exact:true})).toBeFocused();
+    await page.screenshot({path:path.join(screenshots!,"web-query-error.png"),fullPage:true});
+    await editor.getByRole("button",{name:"Save query draft"}).click();
+    const saved=page.getByRole("dialog",{name:"Saved queries and highlights"});
+    await saved.getByLabel("Definition name",{exact:true}).fill("Synthetic review");
+    await saved.getByRole("button",{name:"Save as new",exact:true}).click();
+    await expect(saved.getByText("Saved Synthetic review.",{exact:true})).toBeVisible();
+    await saved.getByRole("button",{name:"Open query Synthetic review"}).click();
+    await expect(editor.getByLabel("Query expression",{exact:true})).toHaveValue("NOT tag:missing-tag");
+    const retained=JSON.parse(new URLSearchParams(new URL(page.url()).hash.slice(1)).get("query")!);
+    expect(retained.filters).toEqual(initial.filters);
+    expect(searches).toEqual([]);
+  } finally {
+    await run("daemon","stop");
+    const status=JSON.parse(await run("daemon","status","--json"));
+    if(status.running!==false) throw new Error("Synthetic query daemon remains running; workspace retained.");
+    await rm(workspace,{recursive:true,force:true});
+  }
+});

--- a/frontend/src/App.queryBar.test.ts
+++ b/frontend/src/App.queryBar.test.ts
@@ -1,0 +1,35 @@
+import { createHash } from "node:crypto";
+import { afterEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import App from "./App.svelte";
+
+const query = {v:1,text:"name:manual OR saved:review",syntax:"advanced",mode:"lexical",filters:{exclude_tag_ids:["11111111-1111-4111-8111-111111111111"]},sort:{field:"size",direction:"desc"}};
+afterEach(() => { cleanup(); history.replaceState(null,"","/"); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+it("opens full URL intent in the editor and keeps edits through save and reopening without executing", async () => {
+  history.replaceState(null,"",`/#web_session=synthetic&web_upload_secret=proof&query=${encodeURIComponent(JSON.stringify(query))}`);
+  vi.stubGlobal("ResizeObserver",class {observe(){} unobserve(){} disconnect(){}});
+  const root = {id:1,name:"",kind:"dir",path:"/",revision:1,size:0,created_at:"2026-01-01T00:00:00Z",modified_at:"2026-01-01T00:00:00Z"};
+  const fetch = vi.spyOn(globalThis,"fetch").mockImplementation(async (input, init) => {
+    const url = String(input);
+    if (url === "/api/v1/queries/parse") return new Response(JSON.stringify({query:JSON.parse(String(init?.body)),query_fingerprint:`sha256:${createHash("sha256").update(String(init?.body)).digest("hex")}`,dependencies:[]}));
+    const value = url.includes("/path?") ? root : url.includes("/children?") ? {directory:root,items:[],total:0,limit:1000,offset:0} : {items:[],total:0,limit:url.includes("saved-queries")?100:1000,offset:0};
+    return new Response(JSON.stringify(value));
+  });
+  render(App);
+  await screen.findByRole("region",{name:"Query editor"});
+  expect((screen.getByLabelText("Query expression") as HTMLTextAreaElement).value).toBe(query.text);
+  await fireEvent.input(screen.getByLabelText("Query expression"),{target:{value:"NOT tag:missing"}});
+  await waitFor(() => expect(JSON.parse(new URLSearchParams(location.hash.slice(1)).get("query")!)).toEqual({...query,text:"NOT tag:missing"}));
+  await fireEvent.click(screen.getByRole("button",{name:"Save query draft"}));
+  await screen.findByRole("dialog",{name:"Saved queries and highlights"});
+  expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value)).toEqual({...query,text:"NOT tag:missing"});
+  await fireEvent.click(screen.getByRole("button",{name:"Close"}));
+  await fireEvent.click(screen.getByRole("button",{name:"Close query editor"}));
+  await fireEvent.click(screen.getByRole("button",{name:"Edit query"}));
+  expect((screen.getByLabelText("Query expression") as HTMLTextAreaElement).value).toBe("NOT tag:missing");
+  expect(fetch.mock.calls.some(([url]) => String(url).startsWith("/api/v1/search"))).toBe(false);
+  expect(location.hash).not.toContain("synthetic");
+  await fireEvent.click(screen.getByRole("button",{name:"Discard query draft"}));
+  expect(location.hash).toBe("");
+  expect(screen.queryByRole("region",{name:"Query editor"})).toBeNull();
+});

--- a/frontend/src/App.queryBar.test.ts
+++ b/frontend/src/App.queryBar.test.ts
@@ -1,13 +1,15 @@
 import { createHash } from "node:crypto";
 import { afterEach, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
 import App from "./App.svelte";
 
 const query = {v:1,text:"name:manual OR saved:review",syntax:"advanced",mode:"lexical",filters:{exclude_tag_ids:["11111111-1111-4111-8111-111111111111"]},sort:{field:"size",direction:"desc"}};
-afterEach(() => { cleanup(); history.replaceState(null,"","/"); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+afterEach(() => { cleanup(); history.replaceState(null,"","/"); Reflect.deleteProperty(Element.prototype, "scrollIntoView"); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 it("opens full URL intent in the editor and keeps edits through save and reopening without executing", async () => {
   history.replaceState(null,"",`/#web_session=synthetic&web_upload_secret=proof&query=${encodeURIComponent(JSON.stringify(query))}`);
   vi.stubGlobal("ResizeObserver",class {observe(){} unobserve(){} disconnect(){}});
+  Object.defineProperty(Element.prototype, "scrollIntoView", { configurable: true, value: vi.fn() });
   const root = {id:1,name:"",kind:"dir",path:"/",revision:1,size:0,created_at:"2026-01-01T00:00:00Z",modified_at:"2026-01-01T00:00:00Z"};
   const fetch = vi.spyOn(globalThis,"fetch").mockImplementation(async (input, init) => {
     const url = String(input);
@@ -29,6 +31,22 @@ it("opens full URL intent in the editor and keeps edits through save and reopeni
   expect((screen.getByLabelText("Query expression") as HTMLTextAreaElement).value).toBe("NOT tag:missing");
   expect(fetch.mock.calls.some(([url]) => String(url).startsWith("/api/v1/search"))).toBe(false);
   expect(location.hash).not.toContain("synthetic");
+  await fireEvent.input(screen.getByLabelText("Structured facets JSON"), { target: { value: '{"size_min":' } });
+  await fireEvent.input(screen.getByLabelText("Query expression"), { target: { value: "unfinished draft" } });
+  await fireEvent.click(screen.getByRole("combobox", { name: "Query mode: lexical" }));
+  await fireEvent.click(screen.getByRole("option", { name: "hybrid" }));
+  (screen.getByRole("button", { name: "Close query editor" }) as HTMLButtonElement).click();
+  await tick();
+  expect(screen.queryByRole("region", { name: "Query editor" })).not.toBeNull();
+  expect((screen.getByLabelText("Structured facets JSON") as HTMLTextAreaElement).value).toBe('{"size_min":');
+  expect((screen.getByLabelText("Query expression") as HTMLTextAreaElement).value).toBe("unfinished draft");
+  expect(screen.getByRole("combobox", { name: "Query mode: hybrid" })).toBeTruthy();
+  await fireEvent.input(screen.getByLabelText("Structured facets JSON"), { target: { value: '{"size_min":2}' } });
+  await fireEvent.click(screen.getByRole("button", { name: "Close query editor" }));
+  expect(screen.queryByRole("region", { name: "Query editor" })).toBeNull();
+  await fireEvent.click(screen.getByRole("button", { name: "Edit query" }));
+  expect((screen.getByLabelText("Query expression") as HTMLTextAreaElement).value).toBe("unfinished draft");
+  await fireEvent.input(screen.getByLabelText("Structured facets JSON"), { target: { value: '{"size_min":' } });
   await fireEvent.click(screen.getByRole("button",{name:"Discard query draft"}));
   expect(location.hash).toBe("");
   expect(screen.queryByRole("region",{name:"Query editor"})).toBeNull();

--- a/frontend/src/App.savedQueries.test.ts
+++ b/frontend/src/App.savedQueries.test.ts
@@ -20,12 +20,12 @@ it("restores a full query beside sign-in without running it as empty-text folder
     return new Response(JSON.stringify(value));
   });
   render(App);
-  await screen.findByRole("dialog", { name: "Saved queries and highlights" });
-  expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value)).toEqual(query);
+  await screen.findByRole("region", { name: "Query editor" });
+  expect(JSON.parse(new URLSearchParams(location.hash.slice(1)).get("query")!)).toEqual(query);
   expect(location.hash).not.toContain("web_session");
   expect(location.hash).not.toContain("proof");
   expect(fetch.mock.calls.some(([url]) => String(url).includes("/search"))).toBe(false);
-  await fireEvent.click(screen.getByRole("button", { name: "Close" }));
+  await fireEvent.click(screen.getByRole("button", { name: "Close query editor" }));
   await fireEvent.click(screen.getByRole("button", { name: "Saved queries and highlights" }));
   expect(JSON.parse((screen.getByLabelText("Complete query JSON") as HTMLTextAreaElement).value)).toEqual(query);
   const kept = { ...query, text: "new draft" };

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -53,6 +53,7 @@
   import ShortcutHelpModal from "./ShortcutHelpModal.svelte";
   import StorageDrawer from "./StorageDrawer.svelte";
   import SavedQueriesDrawer from "./SavedQueriesDrawer.svelte";
+  import QueryBar from "./QueryBar.svelte";
   import { parseQuery, type Query } from "./query.js";
   import { queryFromFragment, replaceQueryURL } from "./queryURL.js";
   import TagCatalogModal, {
@@ -171,6 +172,7 @@
   let storageOpen = $state(false);
   let backupsOpen = $state(false);
   let savedQueriesOpen = $state(false);
+  let queryBarOpen = $state(false);
   let savedQueryDraft = $state<Query | null>(null);
   let queryEditorInitial = $state<Query>(parseQuery("{}"));
   let queryURLError = $state("");
@@ -266,7 +268,7 @@
     if (savedQueryDraft) replaceQueryURL(savedQueryDraft);
     if (session) {
       webSession = session.token;
-      if (savedQueryDraft) openSavedQueries();
+      if (savedQueryDraft) queryBarOpen = true;
       void loadRoot();
       void loadTagCatalog();
       const channel = new VerifiedUploadChannel(session, undefined, () => {
@@ -1270,6 +1272,21 @@
     queryEditorInitial = currentQueryDraft();
     savedQueriesOpen = true;
   }
+
+  function openQueryEditor(value?: Query): void {
+    try {
+      keepQueryDraft(value ?? currentQueryDraft());
+      queryBarOpen = true;
+    } catch (cause) {
+      queryURLError = cause instanceof Error ? cause.message : String(cause);
+    }
+  }
+
+  function discardQueryDraft(): void {
+    queryBarOpen = false;
+    savedQueryDraft = null;
+    replaceQueryURL(null);
+  }
 </script>
 
 {#if !webSession}
@@ -1317,6 +1334,7 @@
         </form>
       {/snippet}
       {#snippet right()}
+        <Button size="sm" onclick={() => openQueryEditor()}>Edit query</Button>
         <IconButton size="sm" ariaLabel="Saved queries and highlights" onclick={openSavedQueries}>
           <BookmarkIcon size="14" aria-hidden="true" />
         </IconButton>
@@ -1445,9 +1463,13 @@
     {#if savedQueryDraft}
       <div class="query-draft-notice">
         <span>Query draft retained · not applied to live results</span>
-        <Button size="sm" onclick={openSavedQueries}>Edit query draft</Button>
-        <Button size="sm" onclick={() => { savedQueryDraft = null; replaceQueryURL(null); }}>Discard query draft</Button>
+        <Button size="sm" onclick={discardQueryDraft}>Discard query draft</Button>
       </div>
+    {/if}
+
+    {#if queryBarOpen && savedQueryDraft}
+      <QueryBar session={webSession} query={savedQueryDraft} onchange={keepQueryDraft}
+        onsave={openSavedQueries} onclose={() => (queryBarOpen = false)} onauthfailure={handleFailure} />
     {/if}
 
     <main class="workspace">
@@ -2006,6 +2028,10 @@
         onclose={() => (collectionsOpen = false)}
         onauthfailure={handleFailure}
         onopenmember={openCollectionMember}
+        onnewquery={(id) => {
+          openQueryEditor(parseQuery(JSON.stringify({filters:{collection_ids:[id]}})));
+          collectionsOpen = false;
+        }}
       />
     {/if}
     {#if auditEvidenceOpen}
@@ -2020,6 +2046,7 @@
         session={webSession}
         initialQuery={queryEditorInitial}
         onload={keepQueryDraft}
+        onopenquery={(query) => { openQueryEditor(query); savedQueriesOpen = false; }}
         onclose={() => (savedQueriesOpen = false)}
         onauthfailure={handleFailure}
       />

--- a/frontend/src/CollectionsDrawer.svelte
+++ b/frontend/src/CollectionsDrawer.svelte
@@ -29,9 +29,10 @@
     onclose: () => void;
     onauthfailure: (cause: unknown) => void;
     onopenmember: (node: Node, current: () => boolean) => void | Promise<void>;
+    onnewquery?: (id: string) => void;
   }
 
-  let { session, onclose, onauthfailure, onopenmember }: Props = $props();
+  let { session, onclose, onauthfailure, onopenmember, onnewquery }: Props = $props();
 
   let items = $state<Collection[]>([]);
   let total = $state(0);
@@ -341,6 +342,7 @@
       </section>
 
       {#if selected}
+        {#if onnewquery}<Button onclick={() => selected && onnewquery?.(selected.id)}>New query for this collection</Button>{/if}
         <section class="label-editor" aria-labelledby="collection-label-heading">
           <div class="section-heading">
             <div>

--- a/frontend/src/CollectionsDrawer.test.ts
+++ b/frontend/src/CollectionsDrawer.test.ts
@@ -63,6 +63,19 @@ afterEach(() => {
 });
 
 describe("collections drawer", () => {
+  it("starts a new query from the exact selected collection identity", async () => {
+    vi.spyOn(globalThis,"fetch").mockImplementation(async (input) => {
+      const url=String(input);
+      if(url.includes("/members?")) return json({collection,items:members,total:2,limit:100,offset:0});
+      if(url.endsWith("/label")) return json({ingest_id:collectionID,label:collection.label,revision:3,updated_at:collection.label_updated_at},'"3"');
+      return json({items:[collection],total:1,limit:100,offset:0});
+    });
+    const onnewquery=vi.fn();
+    render(CollectionsDrawer,{session:"session",onclose:vi.fn(),onauthfailure:vi.fn(),onopenmember:vi.fn(),onnewquery});
+    await fireEvent.click(await screen.findByRole("button",{name:"Browse collection Discovery batch"}));
+    await fireEvent.click(await screen.findByRole("button",{name:"New query for this collection"}));
+    expect(onnewquery).toHaveBeenCalledWith(collectionID);
+  });
   it("shows supported collection facts and opens an exact direct member", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);

--- a/frontend/src/QueryBar.svelte
+++ b/frontend/src/QueryBar.svelte
@@ -104,7 +104,7 @@
 </script>
 
 <section class="query-bar" aria-label="Query editor">
-  <div class="heading"><h2>Query editor</h2><Button size="sm" onclick={close}>Close query editor</Button></div>
+  <div class="heading"><h2>Query editor</h2><Button size="sm" disabled={schemaError !== ""} onclick={close}>Close query editor</Button></div>
   <p>Edit complete query intent. This draft does not change the live results below.</p>
   <div class="controls">
     <SelectDropdown value={draft.syntax} options={syntaxOptions} title="Query syntax" onchange={(value) => { draft = {...draft,syntax:value as Query["syntax"]}; validate(true); }} />
@@ -126,7 +126,7 @@
   <div class="summaries" aria-label="Structured facet summaries">
     {#each Object.entries(draft.filters).filter(([, value]) => value !== undefined) as [key, value]}<Chip>{key}: {JSON.stringify(value)}</Chip>{/each}
   </div>
-  {#if schemaError}<p role="alert">{schemaError}</p>{/if}
+  {#if schemaError}<p role="alert">{schemaError} Correct the draft or choose Discard query draft before closing.</p>{/if}
   <div aria-live="polite">
     {#if pending}<span class="checking"><Spinner size={14} /> Validating query…</span>{/if}
     {#if preview}

--- a/frontend/src/QueryBar.svelte
+++ b/frontend/src/QueryBar.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import { untrack } from "svelte";
+  import { Button, Chip, SelectDropdown, Spinner, type SelectDropdownOption } from "@kenn-io/kit-ui";
+  import { APIError } from "./api.js";
+  import { canonicalQuery, parseQuery, type Query } from "./query.js";
+  import { previewQuery, querySelection, type QueryPreview } from "./queryPreview.js";
+
+  interface Props {
+    session: string;
+    query: Query;
+    onchange: (query: Query) => void;
+    onsave: () => void;
+    onclose: () => void;
+    onauthfailure: (cause: unknown) => void;
+  }
+  let { session, query, onchange, onsave, onclose, onauthfailure }: Props = $props();
+  let draft = $state<Query>(untrack(() => parseQuery(canonicalQuery(query))));
+  let facets = $state(untrack(() => JSON.stringify(query.filters, null, 2)));
+  let schemaError = $state("");
+  let failure = $state("");
+  let position = $state<unknown>();
+  let preview = $state<QueryPreview>();
+  let pending = $state(false);
+  let expression: HTMLTextAreaElement;
+  let generation = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let controller: AbortController | undefined;
+  let currentIdentity = "";
+  const syntaxOptions: SelectDropdownOption[] = [{value:"simple",label:"Simple"},{value:"advanced",label:"Advanced"}];
+  const modeOptions: SelectDropdownOption[] = ["lexical","semantic","hybrid"].map((value) => ({value,label:value}));
+  const sortOptions: SelectDropdownOption[] = ["name","path","modified_at","size","media_type","relevance"].map((value) => ({value,label:value}));
+  const directionOptions: SelectDropdownOption[] = [{value:"asc",label:"Ascending"},{value:"desc",label:"Descending"}];
+  const selection = $derived(querySelection(draft.text, position));
+
+  function invalidate() {
+    generation++;
+    if (timer !== undefined) clearTimeout(timer);
+    controller?.abort();
+    timer = undefined;
+    controller = undefined;
+    preview = undefined;
+    failure = "";
+    position = undefined;
+    pending = false;
+  }
+
+  function validate(emit: boolean) {
+    invalidate();
+    schemaError = "";
+    let valid: Query;
+    try {
+      // Preserve raw facet JSON until the strict shared codec checks duplicate
+      // keys and numeric lexemes. JSON.parse here would erase that evidence.
+      const { filters: _filters, ...rest } = draft;
+      valid = parseQuery(`${JSON.stringify(rest).slice(0, -1)},"filters":${facets}}`);
+      draft = valid;
+      currentIdentity = canonicalQuery(valid);
+    } catch (cause) {
+      schemaError = cause instanceof Error ? cause.message : String(cause);
+      currentIdentity = "";
+      return;
+    }
+    if (emit) onchange(valid);
+    const requestGeneration = generation;
+    const identity = currentIdentity;
+    const requestSession = session;
+    pending = true;
+    timer = setTimeout(() => {
+      timer = undefined;
+      const abort = new AbortController();
+      controller = abort;
+      const current = () => requestGeneration === generation && identity === currentIdentity && !abort.signal.aborted;
+      void previewQuery(requestSession, valid, abort.signal).then((result) => {
+        if (current()) preview = result;
+      }).catch((cause: unknown) => {
+        if (!current()) return;
+        if (cause instanceof APIError && cause.status === 401) { onauthfailure(cause); return; }
+        failure = cause instanceof Error ? cause.message : String(cause);
+        if (cause instanceof APIError && cause.code === "invalid_query") position = cause.position;
+      }).finally(() => {
+        if (current()) pending = false;
+      });
+    }, 250);
+  }
+
+  $effect(() => {
+    const canonical = canonicalQuery(query);
+    const activeSession = session;
+    untrack(() => {
+      draft = parseQuery(canonical);
+      facets = JSON.stringify(draft.filters, null, 2);
+      if (activeSession) validate(false);
+      else invalidate();
+    });
+    return () => invalidate();
+  });
+
+  function close() { invalidate(); onclose(); }
+  function focusError() {
+    if (!selection) return;
+    expression.focus();
+    expression.setSelectionRange(selection.start, selection.end);
+  }
+</script>
+
+<section class="query-bar" aria-label="Query editor">
+  <div class="heading"><h2>Query editor</h2><Button size="sm" onclick={close}>Close query editor</Button></div>
+  <p>Edit complete query intent. This draft does not change the live results below.</p>
+  <div class="controls">
+    <SelectDropdown value={draft.syntax} options={syntaxOptions} title="Query syntax" onchange={(value) => { draft = {...draft,syntax:value as Query["syntax"]}; validate(true); }} />
+    <SelectDropdown value={draft.mode} options={modeOptions} title="Query mode" onchange={(value) => { draft = {...draft,mode:value as Query["mode"]}; validate(true); }} />
+    <SelectDropdown value={draft.sort.field} options={sortOptions} title="Query sort" onchange={(value) => { draft = {...draft,sort:{...draft.sort,field:value as Query["sort"]["field"]}}; validate(true); }} />
+    <SelectDropdown value={draft.sort.direction} options={directionOptions} title="Query direction" onchange={(value) => { draft = {...draft,sort:{...draft.sort,direction:value as Query["sort"]["direction"]}}; validate(true); }} />
+  </div>
+  <label for="query-expression">Query expression</label>
+  <textarea id="query-expression" bind:this={expression} value={draft.text} rows="2" spellcheck="false"
+    oninput={(event) => { draft = {...draft,text:event.currentTarget.value}; validate(true); }}></textarea>
+  <details>
+    <summary>Syntax help</summary>
+    <p>Simple syntax treats whitespace-separated words as literal prefixes. Advanced syntax supports quoted phrases, parentheses, AND, OR, NOT, suffix * prefixes, and NEAR/5 proximity.</p>
+    <p>Keep field operands in their Boolean scope, for example <code>name:manual OR collection:archive</code>. References use <code>tag:</code>, <code>collection:</code>, or <code>saved:</code>. The server validates supported fields and values; unknown exclusions block validation.</p>
+  </details>
+  <label for="query-facets">Structured facets JSON</label>
+  <textarea id="query-facets" value={facets} rows="3" spellcheck="false"
+    oninput={(event) => { facets = event.currentTarget.value; validate(true); }}></textarea>
+  <div class="summaries" aria-label="Structured facet summaries">
+    {#each Object.entries(draft.filters).filter(([, value]) => value !== undefined) as [key, value]}<Chip>{key}: {JSON.stringify(value)}</Chip>{/each}
+  </div>
+  {#if schemaError}<p role="alert">{schemaError}</p>{/if}
+  <div aria-live="polite">
+    {#if pending}<span class="checking"><Spinner size={14} /> Validating query…</span>{/if}
+    {#if preview}
+      <p>Query validated. Execution is unavailable.</p>
+      <div class="summaries" aria-label="Resolved query dependencies">
+        {#each preview.dependencies as dependency (`${dependency.kind}:${dependency.id}`)}<Chip>{dependency.kind}: {dependency.id} · revision {dependency.revision}</Chip>{/each}
+      </div>
+    {/if}
+    {#if failure}<p role="alert">{failure}</p>{/if}
+  </div>
+  {#if selection}<Button size="sm" onclick={focusError}>Focus query error</Button>{/if}
+  <div class="controls">
+    <Button disabled={schemaError !== ""} onclick={onsave}>Save query draft</Button>
+    <Button disabled>Run query</Button>
+    <span>The available live-search endpoint cannot honor this complete query. Validation never drops constraints or runs a broader search.</span>
+  </div>
+</section>
+
+<style>
+  .query-bar { display: grid; gap: var(--space-3); padding: var(--space-4); border-bottom: 1px solid var(--border-default); background: var(--bg-raised); }
+  .query-bar p, h2 { margin: 0; }
+  h2 { font-size: var(--font-size-md); }
+  .heading, .controls, .summaries, .checking { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
+  .heading { justify-content: space-between; }
+  .controls > span { color: var(--text-muted); font-size: var(--font-size-sm); flex: 1; min-width: 200px; }
+  textarea { box-sizing: border-box; width: 100%; resize: vertical; padding: var(--space-2); border: 1px solid var(--border-default); border-radius: var(--radius-md); background: var(--bg-base); color: var(--text-primary); font-family: var(--font-mono); }
+  .summaries { overflow-wrap: anywhere; }
+</style>

--- a/frontend/src/QueryBar.test.ts
+++ b/frontend/src/QueryBar.test.ts
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/svelte";
+import { tick } from "svelte";
+import QueryBar from "./QueryBar.svelte";
+import { parseQuery } from "./query.js";
+
+const canonical = '{"filters":{"exclude_tag_ids":["11111111-1111-4111-8111-111111111111"],"size_min":2},"mode":"lexical","sort":{"direction":"desc","field":"size"},"syntax":"advanced","text":"name:manual OR collection:archive","v":1}';
+const query = parseQuery(canonical);
+const response = (text = canonical) => new Response(JSON.stringify({ query: JSON.parse(text),
+  query_fingerprint: `sha256:${createHash("sha256").update(text).digest("hex")}`, dependencies: [] }));
+beforeEach(() => vi.stubGlobal("ResizeObserver", class { observe() {} unobserve() {} disconnect() {} }));
+afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+function open() {
+  const onchange = vi.fn();
+  const onclose = vi.fn();
+  const view = render(QueryBar, { session: "session", query, onchange, onclose, onsave: vi.fn(), onauthfailure: vi.fn() });
+  return { ...view, onchange, onclose };
+}
+
+it("preserves independent facets and sort while editing the entire expression", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(response());
+  const { onchange } = open();
+  await screen.findByText(/Query validated/);
+  expect(screen.getByLabelText("Structured facet summaries").textContent).not.toContain("paths:");
+  expect((screen.getByRole("button", { name: "Run query" }) as HTMLButtonElement).disabled).toBe(true);
+  await fireEvent.input(screen.getByLabelText("Query expression"), { target: { value: "NOT tag:missing" } });
+  expect(onchange).toHaveBeenLastCalledWith({ ...query, text: "NOT tag:missing" });
+  expect(screen.queryByText(/Query validated/)).toBeNull();
+  expect((screen.getByRole("button", { name: "Save query draft" }) as HTMLButtonElement).disabled).toBe(false);
+});
+
+it("keeps invalid and duplicate facet JSON visible without dropping constraints", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(response());
+  const { onchange } = open();
+  for (const raw of ['{"size_min":', '{"size_min":2,"size_min":3}']) {
+    await fireEvent.input(screen.getByLabelText("Structured facets JSON"), { target: { value: raw } });
+    expect((screen.getByLabelText("Structured facets JSON") as HTMLTextAreaElement).value).toBe(raw);
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect((screen.getByRole("button", { name: "Save query draft" }) as HTMLButtonElement).disabled).toBe(true);
+  }
+  expect(onchange).not.toHaveBeenCalled();
+});
+
+it.each(["success", "invalid", "backend"])("ignores an old %s after an edit before the next debounce", async (kind) => {
+  let resolve!: (value: Response) => void;
+  const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(() => new Promise<Response>((done) => { resolve = done; }));
+  open();
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+  const signal = fetch.mock.calls[0][1]?.signal;
+  await fireEvent.input(screen.getByLabelText("Query expression"), { target: { value: "new expression" } });
+  expect(signal?.aborted).toBe(true);
+  resolve(kind === "success" ? response() : new Response(JSON.stringify({code: kind === "invalid" ? "invalid_query" : "internal", detail: "Old failure", position: {offset:0,end:4}}), {status: kind === "invalid" ? 422 : 500}));
+  await new Promise((done) => setTimeout(done, 30));
+  await tick();
+  expect(screen.queryByText(/Query validated|Old failure/)).toBeNull();
+  expect((screen.getByLabelText("Query expression") as HTMLTextAreaElement).value).toBe("new expression");
+});
+
+it("selects a server byte span correctly without stealing focus during validation", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ code:"invalid_query", detail:"Unknown operand", position:{offset:4,end:5} }), {status:422}));
+  const { rerender } = open();
+  await rerender({ query: { ...query, text: "😀x" } });
+  await screen.findByText("Unknown operand");
+  const expression = screen.getByLabelText("Query expression") as HTMLTextAreaElement;
+  await fireEvent.click(screen.getByRole("button", {name:"Focus query error"}));
+  expect(document.activeElement).toBe(expression);
+  expect([expression.selectionStart, expression.selectionEnd]).toEqual([2,3]);
+});
+
+it("aborts pending validation on close and unmount", async () => {
+  let resolve!: (value: Response) => void;
+  const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(() => new Promise<Response>((done) => { resolve = done; }));
+  const { onclose, unmount } = open();
+  await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+  await fireEvent.click(screen.getByRole("button", {name:"Close query editor"}));
+  expect(fetch.mock.calls[0][1]?.signal?.aborted).toBe(true);
+  expect(onclose).toHaveBeenCalledOnce();
+  unmount();
+  resolve(response());
+  await tick();
+  expect(screen.queryByRole("region", {name:"Query editor"})).toBeNull();
+});
+
+it("keeps a newer success when an older failure arrives after it", async () => {
+  let old!: (value:Response)=>void;
+  const fetch=vi.spyOn(globalThis,"fetch").mockImplementationOnce(()=>new Promise<Response>((resolve)=>{old=resolve;}))
+    .mockImplementation(async (_input,init)=>response(String(init?.body)));
+  open();
+  await waitFor(()=>expect(fetch).toHaveBeenCalledTimes(1));
+  await fireEvent.input(screen.getByLabelText("Query expression"),{target:{value:"new expression"}});
+  await screen.findByText(/Query validated/);
+  old(new Response(JSON.stringify({code:"internal",detail:"Obsolete failure"}),{status:500}));
+  await new Promise((resolve)=>setTimeout(resolve,30));
+  expect(screen.getByText(/Query validated/)).toBeTruthy();
+  expect(screen.queryByText("Obsolete failure")).toBeNull();
+});
+
+it("invalidates the old session before accepting a new preview", async () => {
+  let old!: (value:Response)=>void;
+  const fetch=vi.spyOn(globalThis,"fetch").mockImplementationOnce(()=>new Promise<Response>((resolve)=>{old=resolve;}))
+    .mockImplementation(async (_input,init)=>response(String(init?.body)));
+  const {rerender}=open();
+  await waitFor(()=>expect(fetch).toHaveBeenCalledTimes(1));
+  await rerender({session:"replacement"});
+  expect(fetch.mock.calls[0][1]?.signal?.aborted).toBe(true);
+  old(new Response(JSON.stringify({code:"invalid_query",detail:"Old session"}),{status:422}));
+  await screen.findByText(/Query validated/);
+  expect(screen.queryByText("Old session")).toBeNull();
+  expect(new Headers(fetch.mock.calls[1][1]?.headers).get("X-Docbank-Web-Session")).toBe("replacement");
+});

--- a/frontend/src/SavedQueriesDrawer.svelte
+++ b/frontend/src/SavedQueriesDrawer.svelte
@@ -5,10 +5,11 @@
   import { canonicalQuery, parseHighlightSet, parseQuery, type HighlightTerm, type Query } from "./query.js";
   import { createSavedQuery, deleteSavedQuery, listSavedQueries, SavedQueryReceiptError, updateSavedQuery, type Definition, type SavedQuery, type SavedQueryKind } from "./savedQueries.js";
 
-  let { session, initialQuery, onload, onclose, onauthfailure }: {
+  let { session, initialQuery, onload, onclose, onauthfailure, onopenquery }: {
     session: string;
     initialQuery: Query;
     onload: (query: Query) => void;
+    onopenquery?: (query: Query) => void;
     onclose: () => void;
     onauthfailure: (cause: unknown) => void;
   } = $props();
@@ -174,6 +175,7 @@
         {#each items as item (item.id)}
           <div class="definition-row">
             <div><strong>{item.name}</strong><small>{item.kind === "query" ? "Query" : "Highlight set"} · revision {item.revision}</small></div>
+            {#if item.kind === "query" && onopenquery}<Button size="sm" disabled={pending} ariaLabel={`Open query ${item.name}`} onclick={() => item.kind === "query" && onopenquery?.(item.payload)}>Open query</Button>{/if}
             <Button size="sm" disabled={pending} onclick={() => edit(item)} ariaLabel={`Edit ${item.name}`}>Edit</Button>
             <Button size="sm" disabled={pending} onclick={() => { deleting = item; failure = ""; notice = ""; }} ariaLabel={`Delete ${item.name}`}>Delete</Button>
           </div>

--- a/frontend/src/SavedQueriesDrawer.test.ts
+++ b/frontend/src/SavedQueriesDrawer.test.ts
@@ -115,3 +115,11 @@ it("edits bounded highlight terms without offering execution", async () => {
   expect(screen.queryByRole("button", { name: /run/i })).toBeNull();
   expect(screen.queryByRole("button", { name: "Keep query draft" })).toBeNull();
 });
+
+it("opens the exact saved payload through the explicit query-editor action", async () => {
+  vi.spyOn(globalThis,"fetch").mockResolvedValue(json({items:[record],total:1,limit:100,offset:0}));
+  const onopenquery = vi.fn();
+  render(SavedQueriesDrawer,{session:"session",initialQuery:parseQuery("{}"),onload:vi.fn(),onopenquery,onclose:vi.fn(),onauthfailure:vi.fn()});
+  await fireEvent.click(await screen.findByRole("button",{name:"Open query Review PDFs"}));
+  expect(onopenquery).toHaveBeenCalledWith(JSON.parse(canonical));
+});

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -94,6 +94,28 @@ describe("browser authentication", () => {
     );
   });
 
+  it("preserves an untrusted problem position for the query editor", async () => {
+    const position = { offset: 5, end: 8 };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 422,
+          code: "invalid_query",
+          detail: "expected an expression",
+          position,
+        }),
+        { status: 422, headers: { "Content-Type": "application/problem+json" } },
+      ),
+    );
+
+    await expect(requestJSON("/api/v1/queries/parse", "session")).rejects.toMatchObject({
+      message: "expected an expression",
+      status: 422,
+      code: "invalid_query",
+      position,
+    });
+  });
+
   it("addresses audit status and cursor-stable history by node ID", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
       new Response(JSON.stringify({ enabled: true, scopes: [], items: [] }), {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -330,6 +330,7 @@ export interface Problem {
   code?: string;
   detail?: string;
   title?: string;
+  position?: unknown;
 }
 
 export class APIError extends Error {
@@ -337,6 +338,7 @@ export class APIError extends Error {
     message: string,
     readonly status: number,
     readonly code: string,
+    readonly position?: unknown,
   ) {
     super(message);
     this.name = "APIError";
@@ -385,7 +387,7 @@ export async function requestResponse(
   if (!response.ok) {
     const problem = await decodeProblem(response);
     const detail = problem.detail || problem.title || `HTTP ${response.status}`;
-    throw new APIError(detail, response.status, problem.code ?? "");
+    throw new APIError(detail, response.status, problem.code ?? "", problem.position);
   }
   return response;
 }

--- a/frontend/src/queryPreview.test.ts
+++ b/frontend/src/queryPreview.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fixture from "../../internal/query/testdata/identity-vectors.json";
+import { parseQuery } from "./query.js";
+import { previewQuery, querySelection } from "./queryPreview.js";
+
+const defaults = fixture.queries.find((vector) => vector.name === "query_defaults") ?? (() => {
+  throw new Error("missing query_defaults identity fixture");
+})();
+
+const tagID = "11111111-1111-4111-8111-111111111111";
+const savedID = "22222222-2222-4222-8222-222222222222";
+const collectionID = "33333333-3333-4333-8333-333333333333";
+const query = parseQuery(defaults.input_json);
+
+function response(overrides: Record<string, unknown> = {}): Response {
+  return new Response(JSON.stringify({
+    $schema: "http://localhost/schemas/QueryPreview.json",
+    query: JSON.parse(defaults.canonical_utf8),
+    query_fingerprint: defaults.fingerprint,
+    dependencies: [
+      { kind: "tag", id: tagID, revision: 3 },
+      { kind: "saved", id: savedID, revision: 8 },
+      { kind: "collection", id: collectionID, revision: 5 },
+    ],
+    ...overrides,
+  }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("query preview transport", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("posts the canonical query with JSON content type and the caller's abort signal", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response());
+
+    await expect(previewQuery("session", query, controller.signal)).resolves.toEqual({
+      query,
+      query_fingerprint: defaults.fingerprint,
+      dependencies: [
+        { kind: "tag", id: tagID, revision: 3 },
+        { kind: "saved", id: savedID, revision: 8 },
+        { kind: "collection", id: collectionID, revision: 5 },
+      ],
+    });
+
+    const [path, request] = fetchMock.mock.calls[0] ?? [];
+    expect(path).toBe("/api/v1/queries/parse");
+    expect(request?.method).toBe("POST");
+    expect(request?.body).toBe(defaults.canonical_utf8);
+    expect(new Headers(request?.headers).get("Content-Type")).toBe("application/json");
+    expect(request?.signal).toBe(controller.signal);
+  });
+
+  it.each([
+    ["a different canonical query", { query: { ...JSON.parse(defaults.canonical_utf8), text: "changed" } }],
+    ["a different fingerprint", { query_fingerprint: `sha256:${"0".repeat(64)}` }],
+  ])("rejects a receipt with %s", async (_name, overrides) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response(overrides));
+    await expect(previewQuery("session", query, new AbortController().signal)).rejects.toThrow(
+      /query preview receipt/i,
+    );
+  });
+
+  it.each([
+    ["a non-object envelope", null],
+    ["a missing field", { query: JSON.parse(defaults.canonical_utf8), query_fingerprint: defaults.fingerprint }],
+    ["an unknown envelope field", {
+      query: JSON.parse(defaults.canonical_utf8), query_fingerprint: defaults.fingerprint,
+      dependencies: [], future: true,
+    }],
+    ["an invalid schema link", {
+      $schema: 7, query: JSON.parse(defaults.canonical_utf8),
+      query_fingerprint: defaults.fingerprint, dependencies: [],
+    }],
+    ["an incomplete query", { query: {}, query_fingerprint: defaults.fingerprint, dependencies: [] }],
+    ["an invalid QueryV1 value", {
+      query: { ...JSON.parse(defaults.canonical_utf8), syntax: "future" },
+      query_fingerprint: defaults.fingerprint, dependencies: [],
+    }],
+    ["an unknown dependency field", {
+      query: JSON.parse(defaults.canonical_utf8), query_fingerprint: defaults.fingerprint,
+      dependencies: [{ kind: "tag", id: tagID, revision: 1, name: "Synthetic" }],
+    }],
+    ["an invalid dependency ID", {
+      query: JSON.parse(defaults.canonical_utf8), query_fingerprint: defaults.fingerprint,
+      dependencies: [{ kind: "tag", id: "not-an-id", revision: 1 }],
+    }],
+  ])("rejects %s", async (_name, receipt) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(receipt), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(previewQuery("session", query, new AbortController().signal)).rejects.toThrow(
+      /query preview receipt/i,
+    );
+  });
+
+  it.each([
+    ["unknown dependency kind", [{ kind: "folder", id: tagID, revision: 1 }]],
+    ["coerced dependency kind", [{ kind: ["tag"], id: tagID, revision: 1 }]],
+    ["duplicate dependency identity", [
+      { kind: "tag", id: tagID, revision: 1 },
+      { kind: "tag", id: tagID, revision: 2 },
+    ]],
+    ["unsafe dependency revision", [{ kind: "tag", id: tagID, revision: 9_007_199_254_740_992 }]],
+    ["fractional dependency revision", [{ kind: "tag", id: tagID, revision: 1.5 }]],
+    ["non-positive dependency revision", [{ kind: "tag", id: tagID, revision: 0 }]],
+    [">256 dependencies", Array.from({ length: 257 }, (_, index) => ({
+      kind: "tag",
+      id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+      revision: 1,
+    }))],
+  ])("rejects %s", async (_name, dependencies) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response({ dependencies }));
+    await expect(previewQuery("session", query, new AbortController().signal)).rejects.toThrow(
+      /query preview receipt/i,
+    );
+  });
+});
+
+describe("query error selection", () => {
+  it("maps exact UTF-8 byte boundaries to UTF-16 editor offsets", () => {
+    expect(querySelection("alpha", { offset: 1, end: 4 })).toEqual({ start: 1, end: 4 });
+    expect(querySelection("😀x", { offset: 4, end: 5 })).toEqual({ start: 2, end: 3 });
+  });
+
+  it("preserves an empty half-open span as an editor caret", () => {
+    expect(querySelection("x", { offset: 0, end: 0 })).toEqual({ start: 0, end: 0 });
+    expect(querySelection("😀x", { offset: 4, end: 4 })).toEqual({ start: 2, end: 2 });
+  });
+
+  it("rejects spans inside a scalar, outside the text, or in reverse", () => {
+    expect(querySelection("😀x", { offset: 1, end: 4 })).toBeNull();
+    expect(querySelection("x", { offset: 0, end: 2 })).toBeNull();
+    expect(querySelection("x", { offset: 1, end: 0 })).toBeNull();
+  });
+
+  it.each([null, [], {}, { offset: 0 }, { offset: 0.5, end: 1 }, { offset: -1, end: 1 }])(
+    "rejects an untrusted position %#",
+    (position) => expect(querySelection("x", position)).toBeNull(),
+  );
+});

--- a/frontend/src/queryPreview.ts
+++ b/frontend/src/queryPreview.ts
@@ -1,0 +1,128 @@
+import { requestJSON } from "./api.js";
+import {
+  canonicalQuery,
+  parseQuery,
+  queryFingerprint,
+  type Query,
+} from "./query.js";
+
+export interface QueryPreview {
+  query: Query;
+  query_fingerprint: string;
+  dependencies: {
+    kind: "tag" | "collection" | "saved";
+    id: string;
+    revision: number;
+  }[];
+}
+
+const dependencyKinds = new Set(["tag", "collection", "saved"]);
+const uuidV4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const encoder = new TextEncoder();
+
+function malformed(reason: string): never {
+  throw new Error(`Malformed query preview receipt: ${reason}.`);
+}
+
+function object(value: unknown, field: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    malformed(`${field} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireKeys(value: Record<string, unknown>, expected: readonly string[], field: string): void {
+  const keys = Object.keys(value);
+  if (keys.length !== expected.length || expected.some((key) => !Object.hasOwn(value, key))) {
+    malformed(`${field} has missing or unknown fields`);
+  }
+}
+
+export async function previewQuery(
+  session: string,
+  query: Query,
+  signal: AbortSignal,
+): Promise<QueryPreview> {
+  const canonical = canonicalQuery(query);
+  const expected = await queryFingerprint(query);
+  const raw = await requestJSON<unknown>("/api/v1/queries/parse", session, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: canonical,
+    signal,
+  });
+
+  const receipt = object(raw, "receipt");
+  const receiptKeys = Object.hasOwn(receipt, "$schema")
+    ? ["$schema", "query", "query_fingerprint", "dependencies"]
+    : ["query", "query_fingerprint", "dependencies"];
+  requireKeys(receipt, receiptKeys, "receipt");
+  if (Object.hasOwn(receipt, "$schema") &&
+    (typeof receipt.$schema !== "string" || receipt.$schema.length === 0)) {
+    malformed("receipt.$schema is invalid");
+  }
+
+  const rawQuery = object(receipt.query, "query");
+  requireKeys(rawQuery, ["v", "text", "syntax", "mode", "filters", "sort"], "query");
+  object(rawQuery.filters, "query.filters");
+  const rawSort = object(rawQuery.sort, "query.sort");
+  requireKeys(rawSort, ["field", "direction"], "query.sort");
+
+  let decoded: Query;
+  try {
+    decoded = parseQuery(JSON.stringify(rawQuery));
+  } catch {
+    malformed("query does not satisfy QueryV1");
+  }
+  if (canonicalQuery(decoded) !== canonical) malformed("query does not match the request");
+  if (receipt.query_fingerprint !== expected) malformed("fingerprint does not match the request");
+  if (!Array.isArray(receipt.dependencies) || receipt.dependencies.length > 256) {
+    malformed("dependencies must be an array of at most 256 identities");
+  }
+
+  const identities = new Set<string>();
+  const dependencies: QueryPreview["dependencies"] = receipt.dependencies.map((value, index) => {
+    const dependency = object(value, `dependencies[${index}]`);
+    requireKeys(dependency, ["kind", "id", "revision"], `dependencies[${index}]`);
+    if (typeof dependency.kind !== "string" || !dependencyKinds.has(dependency.kind)) {
+      malformed(`dependencies[${index}].kind is unknown`);
+    }
+    if (typeof dependency.id !== "string" || !uuidV4.test(dependency.id)) {
+      malformed(`dependencies[${index}].id is invalid`);
+    }
+    if (typeof dependency.revision !== "number" ||
+      !Number.isSafeInteger(dependency.revision) || dependency.revision < 1) {
+      malformed(`dependencies[${index}].revision is invalid`);
+    }
+    const kind = dependency.kind as QueryPreview["dependencies"][number]["kind"];
+    const identity = `${kind}\0${dependency.id}`;
+    if (identities.has(identity)) malformed(`dependencies[${index}] repeats an identity`);
+    identities.add(identity);
+    return { kind, id: dependency.id, revision: dependency.revision };
+  });
+
+  return { query: decoded, query_fingerprint: expected, dependencies };
+}
+
+export function querySelection(
+  text: string,
+  position: unknown,
+): { start: number; end: number } | null {
+  if (position === null || typeof position !== "object" || Array.isArray(position)) return null;
+  const span = position as Record<string, unknown>;
+  if (!Number.isSafeInteger(span.offset) || !Number.isSafeInteger(span.end) ||
+    typeof span.offset !== "number" || typeof span.end !== "number" ||
+    span.offset < 0 || span.end < span.offset) return null;
+
+  const boundaries = new Map<number, number>([[0, 0]]);
+  let byteOffset = 0;
+  let codeUnitOffset = 0;
+  for (const point of text) {
+    byteOffset += encoder.encode(point).length;
+    codeUnitOffset += point.length;
+    boundaries.set(byteOffset, codeUnitOffset);
+  }
+  const start = boundaries.get(span.offset);
+  const end = boundaries.get(span.end);
+  return start === undefined || end === undefined ? null : { start, end };
+}


### PR DESCRIPTION
Edit complete search queries without losing their filters, mode, or sort order. Start in **Edit query**, open a saved query, or create a draft for an import collection. Keep the full draft in the tab and URL, or save it as a named definition. Malformed drafts must be corrected or explicitly discarded before closing the editor.

The server validates each draft as you type. Syntax help and highlighted errors help you correct expressions, and newer edits supersede older validation responses. **Run query** remains unavailable; validation does not execute a search or drop constraints to fit ordinary live search.

![Complete query validation with a synthetic collection filter](https://raw.githubusercontent.com/salmonumbrella/docbank/6fb3866c17578acece7d575212f21c1a83fc4746/web-query-bar.png)

![An unknown tag exclusion stays an error and is highlighted in the editor](https://raw.githubusercontent.com/salmonumbrella/docbank/6fb3866c17578acece7d575212f21c1a83fc4746/web-query-error.png)
