### PR TITLE
ci: check documentation upload inputs without Vercel credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,19 +53,8 @@ jobs:
           node --test scripts/docs/*.test.mjs
           make docs-build
 
-      - name: Verify Vercel upload boundary
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-        run: |
-          if [ -z "$VERCEL_TOKEN" ]; then
-            echo "VERCEL_TOKEN must be configured for trusted main-branch documentation checks" >&2
-            exit 1
-          fi
-          npm install --global vercel@58.4.4
-          mkdir -p .superpowers
-          vercel deploy --dry --json --project docbank.ai --scope kenn-software --token "$VERCEL_TOKEN" > .superpowers/vercel-dry-run.json
-          node scripts/docs/assert-vercel-dry-run.mjs .superpowers/vercel-dry-run.json
+      - name: Verify documentation upload inputs locally
+        run: node scripts/docs/check-upload-inputs.mjs
 
       - name: Verify documentation in Chromium and WebKit
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,10 @@ Instructions for autonomous coding agents working in this repository.
   an unpromoted production build, verifies it and the release boundary, and
   then promotes it. The deploy path does not generate screenshots, build the
   product, run Docker, or install frontend dependencies. Pull-request jobs
-  never receive Vercel credentials; the authenticated upload dry run is a
-  trusted `main`-push check, and the manual production workflow validates its
-  requested source without credentials before entering the protected
-  environment.
+  never receive Vercel credentials; CI checks local upload inputs against
+  `.vercelignore`, the allowlist, and the size limit without calling Vercel.
+  The manual production workflow validates its requested source without
+  credentials before entering the protected environment.
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -129,10 +129,10 @@ the release policy from `main` before the protected production job receives
 the validated SHA. It has no automatic push, pull-request, tag, or release
 trigger.
 
-Pull-request documentation checks never receive Vercel credentials.
-CI's authenticated upload dry run runs only after a trusted push to `main` and
-requires the repository `VERCEL_TOKEN` secret. The production wrapper repeats
-that check before upload. Production deployment requires
+CI checks local files selected by `.vercelignore` against the upload allowlist
+and 10 MiB limit. This check runs on pull requests and `main` without Vercel
+credentials or API calls. The production wrapper checks Vercel's actual dry-run
+report before upload. Production deployment requires
 the `VERCEL_TOKEN`, `VERCEL_ORG_ID`, and `VERCEL_PROJECT_ID` secrets on the
 protected `production` environment.
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/svelte": "5.3.1",
         "@tsconfig/svelte": "5.0.8",
         "@types/node": "26.0.0",
+        "ignore": "7.0.5",
         "jsdom": "29.1.1",
         "svelte-check": "4.7.2",
         "typescript": "6.0.3",
@@ -2282,6 +2283,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/is-potential-custom-element-name": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@testing-library/svelte": "5.3.1",
     "@tsconfig/svelte": "5.0.8",
     "@types/node": "26.0.0",
+    "ignore": "7.0.5",
     "jsdom": "29.1.1",
     "svelte-check": "4.7.2",
     "typescript": "6.0.3",

--- a/scripts/docs/check-upload-inputs.mjs
+++ b/scripts/docs/check-upload-inputs.mjs
@@ -1,0 +1,44 @@
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { assertUploadBoundary } from "./assert-vercel-dry-run.mjs";
+
+const require = createRequire(new URL("../../frontend/package.json", import.meta.url));
+const ignore = require("ignore");
+
+export async function collectUploadInputs(root) {
+  const excluded = ignore().add(await readFile(path.join(root, ".vercelignore"), "utf8"));
+  const files = [];
+  async function visit(directory) {
+    const entries = await readdir(path.join(root, directory), { withFileTypes: true });
+    for (const entry of entries) {
+      const relative = directory ? `${directory}/${entry.name}` : entry.name;
+      if (excluded.ignores(relative + (entry.isDirectory() ? "/" : ""))) continue;
+      if (entry.isDirectory()) {
+        await visit(relative);
+      } else if (entry.isFile()) {
+        const { size } = await lstat(path.join(root, relative));
+        files.push({ path: relative, size });
+      } else {
+        throw new Error(`unsupported upload input: ${relative}`);
+      }
+    }
+  }
+  await visit("");
+  return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  try {
+    const root = fileURLToPath(new URL("../../", import.meta.url));
+    const files = await collectUploadInputs(root);
+    const uploads = assertUploadBoundary(files);
+    process.stdout.write(`validated ${uploads.length} local documentation upload files\n`);
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/docs/check-upload-inputs.test.mjs
+++ b/scripts/docs/check-upload-inputs.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { collectUploadInputs } from "./check-upload-inputs.mjs";
+import { assertUploadBoundary } from "./assert-vercel-dry-run.mjs";
+
+test("checks included local files and their sizes, including untracked inputs", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "docbank-upload-inputs-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(path.join(root, ".vercelignore"), "/*\n!/website\n");
+  await mkdir(path.join(root, "website"));
+  await writeFile(path.join(root, "website", "index.html"), "hello");
+  await writeFile(path.join(root, "excluded.txt"), "excluded");
+  assert.deepEqual(await collectUploadInputs(root), [
+    { path: "website/index.html", size: 5 },
+  ]);
+
+  await writeFile(path.join(root, ".vercelignore"), "/*\n!/website\n!/vercel.json\n");
+  await writeFile(path.join(root, "vercel.json"), "{}");
+  const required = [
+    "docs/zensical.toml", "docs/uv.lock", "scripts/vercel-install-docs.sh",
+    "scripts/vercel-build-docs.sh", "scripts/sync-docs-assets.sh",
+    "scripts/docs-assets.ref", "scripts/docs-assets.txt", "scripts/docs/build.mjs",
+    "scripts/docs/verify-site.mjs", "scripts/install.sh", "scripts/install.ps1",
+  ].map((file) => ({ path: file, size: 1 }));
+  const valid = [...required, ...await collectUploadInputs(root)];
+  assert.doesNotThrow(() => assertUploadBoundary(valid));
+  await writeFile(path.join(root, "website", "unexpected.txt"), "extra");
+  const unexpected = [...required, ...await collectUploadInputs(root)];
+  assert.throws(() => assertUploadBoundary(unexpected), /forbidden upload/);
+  await rm(path.join(root, "website", "unexpected.txt"));
+  await writeFile(path.join(root, "website", "index.html"), Buffer.alloc(10 * 1024 * 1024));
+  const oversized = [...required, ...await collectUploadInputs(root)];
+  assert.throws(() => assertUploadBoundary(oversized), /upload exceeds 10 MiB limit/);
+});


### PR DESCRIPTION
Documentation CI no longer needs a Vercel token. The site build was passing, but main-branch CI failed when the upload dry run found no credential.

The replacement reads `.vercelignore` locally and applies the existing required-file, upload allowlist, and 10 MiB checks on both pull requests and main. Deployment still checks Vercel's actual upload report before uploading.
