### PR TITLE
ci: pull the pinned MinIO image from Quay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
           docker run --rm -d --name "$name" \
             -p 127.0.0.1::9000 \
             -e MINIO_ROOT_USER -e MINIO_ROOT_PASSWORD \
-            minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
+            quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e \
             server /data >/dev/null
           port="$(docker port "$name" 9000/tcp | head -1 | awk -F: '{print $NF}')"
           endpoint="http://127.0.0.1:${port}"


### PR DESCRIPTION
Linux CI currently stops before running tests because Docker Hub denies access to the pinned MinIO image. Pull that same digest from Quay, where it remains available.

The image pulled, started, and passed its health check locally. This change needs to land on `main` because pull requests, including #312, call the reusable CI workflow from `main`.
