### PR TITLE
ci: run web checks on GitHub-hosted Ubuntu

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,8 +1,8 @@
 name: CI
 
 # The PR dispatcher always calls the main-pinned workflow. That workflow
-# independently routes same-repository Linux jobs to the managed public fleet
-# and fork jobs to GitHub-hosted runners.
+# independently routes same-repository Linux Go and documentation jobs to the
+# managed public fleet. Web application and fork jobs use GitHub-hosted runners.
 on:
   pull_request:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
 
   frontend:
     name: Web application
-    runs-on: ${{ github.repository == 'kenn-io/docbank' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    # Keep web checks here until self-hosted Node/npm provisioning is reliable.
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Run web CI on GitHub-hosted Ubuntu, matching release frontend builds. In [run #755](https://github.com/kenn-io/docbank/actions/runs/34662868898/job/103468835262), Node setup ended without making npm available on the self-hosted runner, so the web checks failed before starting. This moves the job off that runner pool while its Node/npm provisioning is repaired.

PR CI calls the workflow from `main`, so the new routing takes effect after merge. A later successful default-branch CI run is still needed to confirm recovery.
